### PR TITLE
chore: expand logger doc comment (intentional CI failure test)

### DIFF
--- a/lib/core/logging/logger.dart
+++ b/lib/core/logging/logger.dart
@@ -2,7 +2,8 @@ import 'dart:developer' as developer;
 
 import 'package:logging/logging.dart';
 
-/// App-wide logger configuration. Call [configureLogging] once at startup.
+/// App-wide logger configuration. Call [configureLogging] once at
+/// application startup, before any logging happens.
 void configureLogging({Level level = Level.INFO}) {
   Logger.root.level = level;
   Logger.root.onRecord.listen((record) {


### PR DESCRIPTION
## Summary
- **Intentional failure test** for the GUARD-08 branch ruleset.
- Touches `lib/core/logging/logger.dart` (a doc comment change) without touching `test/`, so `PR hygiene`'s "Require tests when lib changes" step should fail.
- If the ruleset's required status checks are wired correctly, the merge button should be blocked.

## Test plan
- [ ] `PR hygiene` **fails** (lib/ changed, test/ not changed)
- [ ] `Analyze & test` passes (change is a pure doc comment)
- [ ] Merge button on GitHub is disabled / blocked by the ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)