### PR TITLE
chore: record firebase project id for FIRE-01

### DIFF
--- a/firebase/.project-id
+++ b/firebase/.project-id
@@ -1,0 +1,1 @@
+picklist-by


### PR DESCRIPTION
## Summary
- Records the Firebase project ID `picklist-by` at `firebase/.project-id` per FIRE-01.
- Farm owner has run `firebase login` and `flutterfire configure --project=picklist-by` locally. Generated files (`lib/firebase_options.dart`, `google-services.json`, `GoogleService-Info.plist`) are **not** included here — commit/ignore policy is decided in [FIRE-02](https://github.com/amirorgani/pickllist/issues/10).

Closes #9.

## Test plan
- [ ] `PR hygiene` passes (conventional title, no lib/ changes)
- [ ] `Analyze & test` passes