### PR TITLE
chore: set minimum CMake policy version for Firebase compatibility

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -10,6 +10,10 @@ set(BINARY_NAME "pickllist")
 # versions of CMake.
 cmake_policy(VERSION 3.14...3.25)
 
+# FlutterFire extracts a Firebase C++ SDK CMake project whose published
+# cmake_minimum_required can be older than modern CMake accepts.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 # Define build configuration option.
 get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(IS_MULTICONFIG)


### PR DESCRIPTION
## Summary

fixed windows build issues with cmake version

## Checklist

- [ ] Tests added or updated for non-mechanical changes.
- [ ] `flutter analyze --fatal-infos` passes locally.
- [ ] `flutter test` passes locally.
- [ ] Coverage guardrails still pass, or the ratchet/docs were updated deliberately.
- [ ] `docs/` updated for behavior, process, or dependency changes.
- [ ] All new user-visible strings were added to `app_en.arb`, `app_he.arb`, and `app_th.arb`.
- [ ] Windows-only manager features stay behind `PlatformInfo.managerFeaturesAvailable`.
