### PR TITLE
chore: enforce coverage ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,20 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage --reporter=expanded
 
+      - name: Check coverage ratchet on pull requests
+        if: github.event_name == 'pull_request'
+        run: >
+          dart run tool/check_coverage.dart
+          --base "${{ github.event.pull_request.base.sha }}"
+          --head "${{ github.event.pull_request.head.sha }}"
+
+      - name: Check coverage ratchet on pushes
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        run: >
+          dart run tool/check_coverage.dart
+          --base "${{ github.event.before }}"
+          --head "${{ github.sha }}"
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         if: always()

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,0 +1,19 @@
+# Guardrails
+
+This repo is AI-operated, so CI guardrails prevent silent quality regressions
+before feature work reaches users.
+
+## Coverage ratchet
+
+CI runs `flutter test --coverage` and then `dart run tool/check_coverage.dart`.
+The check compares `coverage/lcov.info` against the committed baseline in
+`tool/coverage_baseline.json`.
+
+- Overall project coverage must not fall below the committed baseline.
+- Touched files under `lib/features/**/domain/` and `lib/features/**/data/`
+  must stay at or above 80% line coverage.
+- The long-term pre-ship target is 90% overall coverage.
+
+The ratchet only moves upward through an explicit PR change to
+`tool/coverage_baseline.json`. When `main` improves, update that file in the
+same PR as the improvement so future PRs cannot regress below the new level.

--- a/test/tool/check_coverage_test.dart
+++ b/test/tool/check_coverage_test.dart
@@ -1,0 +1,254 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/check_coverage.dart';
+
+void main() {
+  group('CoverageCheckConfig.fromArgs', () {
+    test('parses required refs and optional thresholds', () {
+      final config = CoverageCheckConfig.fromArgs([
+        '--base',
+        'origin/main',
+        '--head',
+        'HEAD',
+        '--lcov',
+        'custom/lcov.info',
+        '--baseline',
+        'custom/baseline.json',
+        '--touched-min',
+        '75.5',
+      ]);
+
+      expect(config.baseRef, 'origin/main');
+      expect(config.headRef, 'HEAD');
+      expect(config.lcovPath, 'custom/lcov.info');
+      expect(config.baselinePath, 'custom/baseline.json');
+      expect(config.touchedFileMinimumPercent, 75.5);
+    });
+
+    test('throws when refs are missing', () {
+      expect(
+        () => CoverageCheckConfig.fromArgs(['--base', 'origin/main']),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('CoverageBaseline.fromJson', () {
+    test('reads overall baseline percentage', () {
+      final baseline = CoverageBaseline.fromJson(
+        jsonDecode('{"overallPercent": 42.5}'),
+      );
+
+      expect(baseline.overallPercent, 42.5);
+    });
+
+    test('rejects missing overall percentage', () {
+      expect(
+        () => CoverageBaseline.fromJson(jsonDecode('{"coverage": 42.5}')),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('CoverageReport.parse', () {
+    test('normalizes paths and computes file and overall coverage', () {
+      final report = CoverageReport.parse('''
+SF:lib\\features\\auth\\data\\auth_repository.dart
+DA:1,1
+DA:2,0
+LF:2
+LH:1
+end_of_record
+SF:lib/features/auth/domain/app_user.dart
+DA:1,1
+DA:2,1
+LF:2
+LH:2
+end_of_record
+''');
+
+      expect(
+        report.files.keys,
+        contains('lib/features/auth/data/auth_repository.dart'),
+      );
+      expect(
+        report.files['lib/features/auth/data/auth_repository.dart']?.percent,
+        50,
+      );
+      expect(report.overallPercent, 75);
+    });
+  });
+
+  group('evaluateCoverage', () {
+    test('passes when overall and touched domain/data files meet gates', () {
+      final report = CoverageReport.parse('''
+SF:lib/features/picking_lists/domain/picking_item.dart
+LF:10
+LH:9
+end_of_record
+SF:lib/app.dart
+LF:10
+LH:1
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 50),
+        baseBaseline: const CoverageBaseline(overallPercent: 50),
+        changedFiles: [
+          'lib/features/picking_lists/domain/picking_item.dart',
+          'lib/app.dart',
+        ],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails when overall coverage drops below baseline', () {
+      final report = CoverageReport.parse('''
+SF:lib/features/auth/data/auth_repository.dart
+LF:10
+LH:4
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 50),
+        baseBaseline: const CoverageBaseline(overallPercent: 50),
+        changedFiles: const [],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.failures.single, contains('below baseline 50.00%'));
+    });
+
+    test('fails touched domain/data files below threshold', () {
+      final report = CoverageReport.parse('''
+SF:lib/features/auth/data/auth_repository.dart
+LF:10
+LH:7
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 10),
+        baseBaseline: const CoverageBaseline(overallPercent: 10),
+        changedFiles: const ['lib/features/auth/data/auth_repository.dart'],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.failures.single, contains('coverage 70.00% is below 80%'));
+    });
+
+    test('fails touched domain/data files missing from lcov', () {
+      final report = CoverageReport.parse('''
+SF:lib/app.dart
+LF:10
+LH:10
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 10),
+        baseBaseline: const CoverageBaseline(overallPercent: 10),
+        changedFiles: const ['lib/features/auth/domain/app_user.dart'],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.failures.single, contains('has no coverage entry'));
+    });
+
+    test('allows first baseline when base branch has no baseline file', () {
+      final report = CoverageReport.parse('''
+SF:lib/app.dart
+LF:10
+LH:5
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 50),
+        baseBaseline: null,
+        changedFiles: const [],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('allows upward baseline changes', () {
+      final report = CoverageReport.parse('''
+SF:lib/app.dart
+LF:10
+LH:7
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 60),
+        baseBaseline: const CoverageBaseline(overallPercent: 50),
+        changedFiles: const [],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('rejects downward baseline changes', () {
+      final report = CoverageReport.parse('''
+SF:lib/app.dart
+LF:10
+LH:7
+end_of_record
+''');
+
+      final result = evaluateCoverage(
+        report: report,
+        baseline: const CoverageBaseline(overallPercent: 40),
+        baseBaseline: const CoverageBaseline(overallPercent: 50),
+        changedFiles: const [],
+        touchedFileMinimumPercent: 80,
+      );
+
+      expect(result.passed, isFalse);
+      expect(
+        result.failures.single,
+        contains('below base branch baseline 50.00%'),
+      );
+    });
+  });
+
+  group('isThresholdedPath', () {
+    test('matches feature domain and data dart files only', () {
+      expect(
+        isThresholdedPath('lib/features/auth/domain/app_user.dart'),
+        isTrue,
+      );
+      expect(
+        isThresholdedPath('lib/features/auth/data/auth_repository.dart'),
+        isTrue,
+      );
+      expect(
+        isThresholdedPath('lib/features/auth/presentation/login.dart'),
+        isFalse,
+      );
+      expect(
+        isThresholdedPath('test/features/auth/data/auth_repository_test.dart'),
+        isFalse,
+      );
+      expect(isThresholdedPath('lib/core/router.dart'), isFalse);
+    });
+  });
+}

--- a/tool/check_coverage.dart
+++ b/tool/check_coverage.dart
@@ -1,0 +1,299 @@
+import 'dart:convert';
+import 'dart:io';
+
+const _defaultLcovPath = 'coverage/lcov.info';
+const _defaultBaselinePath = 'tool/coverage_baseline.json';
+const _defaultTouchedFileMinimumPercent = 80.0;
+const _shipTargetPercent = 90.0;
+
+Future<void> main(List<String> args) async {
+  final config = CoverageCheckConfig.fromArgs(args);
+  final report = CoverageReport.parse(
+    await File(config.lcovPath).readAsString(),
+  );
+  final baseline = CoverageBaseline.fromJson(
+    jsonDecode(await File(config.baselinePath).readAsString()),
+  );
+  final baseBaseline = await readBaselineAtRef(
+    ref: config.baseRef,
+    baselinePath: config.baselinePath,
+  );
+  final changedFiles = await changedFilesBetween(
+    baseRef: config.baseRef,
+    headRef: config.headRef,
+  );
+
+  final result = evaluateCoverage(
+    report: report,
+    baseline: baseline,
+    baseBaseline: baseBaseline,
+    changedFiles: changedFiles,
+    touchedFileMinimumPercent: config.touchedFileMinimumPercent,
+  );
+
+  if (result.passed) {
+    stdout.writeln(
+      'Coverage ${report.overallPercent.toStringAsFixed(2)}% meets '
+      'baseline ${baseline.overallPercent.toStringAsFixed(2)}%.',
+    );
+    if (report.overallPercent < _shipTargetPercent) {
+      stdout.writeln(
+        'Coverage remains below the '
+        '${_shipTargetPercent.toStringAsFixed(0)}% pre-ship target.',
+      );
+    }
+    return;
+  }
+
+  for (final failure in result.failures) {
+    stderr.writeln(failure);
+  }
+  exitCode = 1;
+}
+
+class CoverageCheckConfig {
+  CoverageCheckConfig({
+    required this.baseRef,
+    required this.headRef,
+    required this.lcovPath,
+    required this.baselinePath,
+    required this.touchedFileMinimumPercent,
+  });
+
+  factory CoverageCheckConfig.fromArgs(List<String> args) {
+    String? baseRef;
+    String? headRef;
+    var lcovPath = _defaultLcovPath;
+    var baselinePath = _defaultBaselinePath;
+    var touchedFileMinimumPercent = _defaultTouchedFileMinimumPercent;
+
+    for (var i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case '--base':
+          baseRef = _nextValue(args, ++i, '--base');
+        case '--head':
+          headRef = _nextValue(args, ++i, '--head');
+        case '--lcov':
+          lcovPath = _nextValue(args, ++i, '--lcov');
+        case '--baseline':
+          baselinePath = _nextValue(args, ++i, '--baseline');
+        case '--touched-min':
+          touchedFileMinimumPercent = double.parse(
+            _nextValue(args, ++i, '--touched-min'),
+          );
+        default:
+          throw ArgumentError('Unknown argument: ${args[i]}');
+      }
+    }
+
+    if (baseRef == null || headRef == null) {
+      throw ArgumentError('Both --base and --head are required.');
+    }
+
+    return CoverageCheckConfig(
+      baseRef: baseRef,
+      headRef: headRef,
+      lcovPath: lcovPath,
+      baselinePath: baselinePath,
+      touchedFileMinimumPercent: touchedFileMinimumPercent,
+    );
+  }
+
+  final String baseRef;
+  final String headRef;
+  final String lcovPath;
+  final String baselinePath;
+  final double touchedFileMinimumPercent;
+}
+
+class CoverageBaseline {
+  const CoverageBaseline({required this.overallPercent});
+
+  factory CoverageBaseline.fromJson(Object? json) {
+    if (json case {'overallPercent': final num overallPercent}) {
+      return CoverageBaseline(overallPercent: overallPercent.toDouble());
+    }
+
+    throw const FormatException(
+      'Coverage baseline must include numeric overallPercent.',
+    );
+  }
+
+  final double overallPercent;
+}
+
+class CoverageReport {
+  CoverageReport({required this.files});
+
+  factory CoverageReport.parse(String lcovContent) {
+    final files = <String, FileCoverage>{};
+    String? currentPath;
+    var linesFound = 0;
+    var linesHit = 0;
+
+    for (final rawLine in const LineSplitter().convert(lcovContent)) {
+      final line = rawLine.trim();
+      if (line.startsWith('SF:')) {
+        currentPath = normalizePath(line.substring(3));
+        linesFound = 0;
+        linesHit = 0;
+      } else if (line.startsWith('LF:')) {
+        linesFound = int.parse(line.substring(3));
+      } else if (line.startsWith('LH:')) {
+        linesHit = int.parse(line.substring(3));
+      } else if (line == 'end_of_record' && currentPath != null) {
+        files[currentPath] = FileCoverage(
+          path: currentPath,
+          linesFound: linesFound,
+          linesHit: linesHit,
+        );
+        currentPath = null;
+      }
+    }
+
+    return CoverageReport(files: files);
+  }
+
+  final Map<String, FileCoverage> files;
+
+  int get linesFound =>
+      files.values.fold(0, (total, file) => total + file.linesFound);
+
+  int get linesHit =>
+      files.values.fold(0, (total, file) => total + file.linesHit);
+
+  double get overallPercent =>
+      percentage(linesHit: linesHit, linesFound: linesFound);
+}
+
+class FileCoverage {
+  const FileCoverage({
+    required this.path,
+    required this.linesFound,
+    required this.linesHit,
+  });
+
+  final String path;
+  final int linesFound;
+  final int linesHit;
+
+  double get percent => percentage(linesHit: linesHit, linesFound: linesFound);
+}
+
+class CoverageCheckResult {
+  const CoverageCheckResult({required this.failures});
+
+  final List<String> failures;
+
+  bool get passed => failures.isEmpty;
+}
+
+CoverageCheckResult evaluateCoverage({
+  required CoverageReport report,
+  required CoverageBaseline baseline,
+  required CoverageBaseline? baseBaseline,
+  required Iterable<String> changedFiles,
+  required double touchedFileMinimumPercent,
+}) {
+  final failures = <String>[];
+
+  if (baseBaseline != null &&
+      baseline.overallPercent < baseBaseline.overallPercent) {
+    failures.add(
+      'Coverage baseline ${baseline.overallPercent.toStringAsFixed(2)}% is below '
+      'base branch baseline ${baseBaseline.overallPercent.toStringAsFixed(2)}%.',
+    );
+  }
+
+  if (report.overallPercent < baseline.overallPercent) {
+    failures.add(
+      'Overall coverage ${report.overallPercent.toStringAsFixed(2)}% is below '
+      'baseline ${baseline.overallPercent.toStringAsFixed(2)}%.',
+    );
+  }
+
+  for (final path in changedFiles.map(normalizePath).where(isThresholdedPath)) {
+    final coverage = report.files[path];
+    if (coverage == null) {
+      failures.add(
+        '$path has no coverage entry; touched domain/data files require '
+        '${touchedFileMinimumPercent.toStringAsFixed(0)}% coverage.',
+      );
+      continue;
+    }
+
+    if (coverage.percent < touchedFileMinimumPercent) {
+      failures.add(
+        '$path coverage ${coverage.percent.toStringAsFixed(2)}% is below '
+        '${touchedFileMinimumPercent.toStringAsFixed(0)}%.',
+      );
+    }
+  }
+
+  return CoverageCheckResult(failures: failures);
+}
+
+Future<List<String>> changedFilesBetween({
+  required String baseRef,
+  required String headRef,
+}) async {
+  final result = await Process.run('git', [
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMRT',
+    baseRef,
+    headRef,
+  ]);
+
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      'git',
+      ['diff', '--name-only', '--diff-filter=ACMRT', baseRef, headRef],
+      result.stderr.toString(),
+      result.exitCode,
+    );
+  }
+
+  return const LineSplitter()
+      .convert(result.stdout.toString())
+      .map(normalizePath)
+      .where((path) => path.isNotEmpty)
+      .toList(growable: false);
+}
+
+Future<CoverageBaseline?> readBaselineAtRef({
+  required String ref,
+  required String baselinePath,
+}) async {
+  final result = await Process.run('git', ['show', '$ref:$baselinePath']);
+
+  if (result.exitCode != 0) {
+    return null;
+  }
+
+  return CoverageBaseline.fromJson(jsonDecode(result.stdout.toString()));
+}
+
+bool isThresholdedPath(String path) {
+  final normalized = normalizePath(path);
+  return normalized.startsWith('lib/features/') &&
+      (normalized.contains('/domain/') || normalized.contains('/data/')) &&
+      normalized.endsWith('.dart');
+}
+
+double percentage({required int linesHit, required int linesFound}) {
+  if (linesFound == 0) {
+    return 100;
+  }
+
+  return linesHit / linesFound * 100;
+}
+
+String normalizePath(String path) => path.replaceAll('\\', '/');
+
+String _nextValue(List<String> args, int index, String flag) {
+  if (index >= args.length) {
+    throw ArgumentError('Missing value for $flag.');
+  }
+  return args[index];
+}

--- a/tool/coverage_baseline.json
+++ b/tool/coverage_baseline.json
@@ -1,0 +1,5 @@
+{
+  "overallPercent": 40.16,
+  "source": "Generated from flutter test --coverage on main before GUARD-01 implementation.",
+  "shipTargetPercent": 90.0
+}


### PR DESCRIPTION
## Summary
- Adds a testable Dart coverage ratchet tool that parses `coverage/lcov.info`, compares overall coverage against a committed baseline, and enforces >=80% coverage for touched feature `domain/` and `data/` files.
- Wires the ratchet into CI immediately after `flutter test --coverage` for PRs and pushes.
- Documents the ratchet, explicit upward-only baseline updates, and the 90% pre-ship target in `docs/guardrails.md`.

Closes #1

## Tests
- `dart format --output=none --set-exit-if-changed .` — passed
- `flutter gen-l10n` — passed
- `flutter analyze --fatal-infos` — passed
- `flutter test test/tool/check_coverage_test.dart --reporter=expanded` — passed (13 tests)
- `flutter test --coverage --reporter=expanded` — passed (43 tests)
- `dart run tool/check_coverage.dart --base main --head HEAD` — passed (`Coverage 40.16% meets baseline 40.16%.`)
- `dart run custom_lint` — failed before and after the change while building `custom_lint`/`analyzer_plugin` from pub cache due to analyzer API type mismatches (`Element` vs `Element2`); no project lint results were produced.

## Docs / dependencies
- Docs: added `docs/guardrails.md` for the new coverage ratchet.
- Dependencies: no `pubspec.yaml` dependency changes.

## Localization / platform
- Localization: no user-visible app strings changed; `flutter gen-l10n` was run.
- Platform: CI/tooling-only change; no runtime platform behavior changes.

## Self CR
- Re-read issue #1, `AGENTS.md`, and `docs/guardrails.md`.
- Reviewed final diff for acceptance criteria, baseline-lowering bypasses, weak tests, dependency drift, localization/platform impact, and unrelated changes.
- Found and fixed a blocker during review: the first implementation allowed lowering `tool/coverage_baseline.json` in the same PR. The tool now reads the base branch baseline and rejects downward baseline changes while allowing this initial baseline and future upward ratchets.
- Post-fix review agents re-checked goal fit, code quality, and missed context; all passed. Security and QA reviews also passed.
- Residual risk: `dart run custom_lint` is blocked by the existing `custom_lint`/`analyzer_plugin` dependency incompatibility noted above; no known residual risk in the coverage ratchet itself.