### PR TITLE
chore: require returning to main after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,12 @@ jobs:
 
       - name: Validate PR title
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
+          PR_TITLE=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq .title)
+          echo "PR title: $PR_TITLE"
           if [[ ! "$PR_TITLE" =~ ^(feat|fix|docs|test|refactor|chore):\ .+ ]]; then
             echo "::error title=Invalid PR title::PR titles must start with feat:, fix:, docs:, test:, refactor:, or chore:."
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ All repository work follows:
    docs/dependency notes, localization/platform notes, and `Self CR`.
 5. **Merge.** Merge only after required checks pass, self CR is documented, and
    manager feedback is incorporated or deferred to a follow-up issue.
+6. **Return to main.** After the PR is merged, check out `main` and update it
+   to the merged remote state before starting or ending further work.
 
 Do not code on `main`, start work without an issue, or open an unlinked PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ All repository work follows:
    docs/dependency notes, localization/platform notes, and `Self CR`.
 5. **Merge.** Merge only after required checks pass, self CR is documented, and
    manager feedback is incorporated or deferred to a follow-up issue.
-6. **Return to main.** After the PR is merged, check out `main` and update it
+6. **Return to main.** After you merged the PR, check out `main` and update it
    to the merged remote state before starting or ending further work.
 
 Do not code on `main`, start work without an issue, or open an unlinked PR.


### PR DESCRIPTION
## Summary
- Adds Required Workflow point 6 in AGENTS.md telling agents to return to updated main after they merged a PR.
- Updates PR hygiene so title validation fetches the current PR title via GitHub API, avoiding stale title data when a failed check is rerun after retitling.

Closes #56

## Tests
- YAML diagnostics for .github/workflows/ci.yml -- clean
- gh api repos/amirorgani/pickllist/pulls/55 --jq .title -- passed, confirms the title lookup command works
- dart format --output=none --set-exit-if-changed AGENTS.md -- not applicable; Dart formatter treats Markdown as Dart and fails to parse it

## Docs / dependencies
- Docs: updated AGENTS.md Required Workflow.
- Dependencies: no dependency changes.

## Localization / platform
- Localization: no app strings changed.
- Platform: CI/docs-only change; no app runtime platform impact.

## Self CR
- Re-read issue #56 and reviewed the final diff.
- Confirmed the wording matches manager feedback: "After you merged the PR".
- Confirmed the hygiene check now reads the current PR title from the GitHub API instead of the stale pull_request event payload.
- Residual risks: none known.
