### PR TITLE
chore: add Windows build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,36 @@ jobs:
           name: coverage-lcov
           path: coverage/lcov.info
           if-no-files-found: ignore
+
+  windows_build:
+    name: Build Windows app
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: '3.41.x'
+          cache: true
+
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Build Windows app
+        run: flutter build windows --debug
+
+      - name: Upload Windows build artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-debug-build
+          path: build/windows/x64/runner/Debug/
+          if-no-files-found: error

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -100,6 +100,8 @@ The Firebase impls will read these at startup.
 GitHub Actions in `.github/workflows/ci.yml` runs on every push + PR:
 `flutter pub get → dart format check → flutter analyze --fatal-infos →
 flutter gen-l10n → flutter test --coverage` and uploads the lcov
-report as an artifact. No secrets are required for the POC; once
-Firebase is wired we'll add a workflow job that runs the rules tests
-against the Firestore emulator.
+report as an artifact. CI also builds the Windows desktop app with
+`flutter build windows --debug` on a Windows runner and uploads the
+debug build output for smoke checks. No secrets are required for the
+POC; once Firebase is wired we'll add a workflow job that runs the
+rules tests against the Firestore emulator.


### PR DESCRIPTION
## Summary
- Adds a Windows runner CI job that enables Flutter Windows desktop, restores dependencies, generates localizations, and runs `flutter build windows --debug`.
- Uploads the debug Windows build output as an artifact for smoke checks.
- Documents the Windows CI build in `docs/setup.md`.

Closes #58

## Tests
- YAML diagnostics for `.github/workflows/ci.yml` ? clean
- `flutter config --enable-windows-desktop` ? passed
- `flutter pub get` ? passed
- `flutter gen-l10n` ? passed
- `flutter build windows --debug` ? passed (`build\windows\x64\runner\Debug\pickllist.exe`)

## Docs / dependencies
- Docs: updated `docs/setup.md` CI section.
- Dependencies: no dependency changes.

## Localization / platform
- Localization: `flutter gen-l10n` was run before the build.
- Platform: Windows CI build only; no signing or installer packaging added.

## Self CR
- Re-read issue #58 and reviewed final diff.
- Confirmed the workflow runs on `windows-latest`, builds with Flutter 3.41.x, uploads the debug build artifact, and documents the behavior.
- Residual risks: none known.
