### PR TITLE
feat: add roadmap-to-GitHub issue sync script

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -95,6 +95,27 @@ export FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 
 The Firebase impls will read these at startup.
 
+## Issue sync from `docs/roadmap.md`
+
+`tool/sync_issues.dart` mirrors each `## \`<ID>\` — Title` entry in
+`docs/roadmap.md` to a GitHub issue, creating any missing labels and
+toggling the `blocked` label based on whether all listed blockers are
+closed. Re-running it converges existing issues to the roadmap; it is
+idempotent — a second run with no roadmap edits is a no-op.
+
+```sh
+# Preview changes without touching GitHub.
+dart run tool/sync_issues.dart --dry-run
+
+# Apply changes against the default `amirorgani/pickllist` repo
+# (requires `gh auth login`).
+dart run tool/sync_issues.dart
+```
+
+The matching key is the roadmap ID prefix in the issue title (e.g.
+`GUARD-02`). Renaming the title is safe; deleting the prefix breaks the
+link and the next run will create a duplicate issue.
+
 ## CI
 
 GitHub Actions in `.github/workflows/ci.yml` runs on every push + PR:

--- a/test/tool/sync_issues_test.dart
+++ b/test/tool/sync_issues_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/sync_issues.dart';
+
+const _sampleRoadmap = '''
+# Phase 0 — Guardrails
+
+## `GUARD-02` — Tighter analyzer rules
+
+- **Type:** `type:guardrail` · **Phase:** `phase:0` · **Priority:** `priority:p0`
+- **Owner:** agent · **Blocks:** all feature work
+
+**Description.** Replace `flutter_lints` with `very_good_analysis`.
+
+- bullet inside description
+
+**Acceptance criteria:**
+- [ ] `analysis_options.yaml` updated.
+- [ ] All existing code passes the stricter lints.
+
+## `FIRE-01` — Create Firebase project
+
+- **Type:** `type:infra` · **Phase:** `phase:1` · **Priority:** `priority:p0`
+- **Requires:** `requires:human`
+- **Blocks:** `FIRE-02`, `FIRE-03`
+- **Owner:** human
+
+**Description.** Create the Firebase project.
+
+## `FIRE-02` — Commit options strategy
+
+- **Type:** `type:infra` · **Phase:** `phase:1` · **Priority:** `priority:p0`
+- **Blocked by:** `FIRE-01`
+- **Owner:** agent
+
+**Description.** Commit `firebase_options.dart`.
+
+## `FIRE-03` — Auth repo
+
+- **Type:** `type:feature` · **Phase:** `phase:1` · **Priority:** `priority:p0`
+- **Blocked by:** `FIRE-01`, `FIRE-02`, all `GUARD-*`
+- **Owner:** agent
+
+**Description.** Real auth implementation.
+''';
+
+void main() {
+  group('parseRoadmap', () {
+    test('extracts entries with metadata, description, and acceptance', () {
+      final entries = parseRoadmap(_sampleRoadmap);
+      expect(entries, hasLength(4));
+
+      final guard02 = entries[0];
+      expect(guard02.id, 'GUARD-02');
+      expect(guard02.title, 'Tighter analyzer rules');
+      expect(guard02.type, 'type:guardrail');
+      expect(guard02.phase, 'phase:0');
+      expect(guard02.priority, 'priority:p0');
+      expect(guard02.owner, 'agent');
+      expect(guard02.blocksRaw, 'all feature work');
+      expect(guard02.blockedByRaw, isNull);
+      expect(
+        guard02.descriptionLines.first,
+        contains('Replace `flutter_lints`'),
+      );
+      expect(guard02.acceptanceLines, hasLength(2));
+      expect(guard02.acceptanceLines.first, startsWith('- [ ] '));
+    });
+
+    test('captures requires and resolves explicit blocked-by ids', () {
+      final entries = parseRoadmap(_sampleRoadmap);
+      resolveDependencies(entries);
+      final fire02 = entries.firstWhere((e) => e.id == 'FIRE-02');
+      expect(fire02.requires, isNull);
+      expect(fire02.blockedBy, ['FIRE-01']);
+
+      final fire01 = entries.firstWhere((e) => e.id == 'FIRE-01');
+      expect(fire01.requires, '`requires:human`');
+      // Reverse graph derives Blocks from other entries pointing at FIRE-01.
+      expect(fire01.blocks, containsAll(['FIRE-02', 'FIRE-03']));
+    });
+
+    test('expands wildcard blocked-by patterns', () {
+      final source =
+          '$_sampleRoadmap'
+          '\n## `GUARD-01` — Other guardrail\n\n'
+          '- **Type:** `type:guardrail` · **Phase:** `phase:0` · '
+          '**Priority:** `priority:p0`\n'
+          '- **Owner:** agent\n';
+      final entries = parseRoadmap(source);
+      resolveDependencies(entries);
+      final fire03 = entries.firstWhere((e) => e.id == 'FIRE-03');
+      expect(
+        fire03.blockedBy,
+        containsAll(['FIRE-01', 'FIRE-02', 'GUARD-01', 'GUARD-02']),
+      );
+    });
+  });
+
+  group('renderBody', () {
+    test('produces sections in the canonical order', () {
+      final entries = parseRoadmap(_sampleRoadmap);
+      resolveDependencies(entries);
+      final fire02 = entries.firstWhere((e) => e.id == 'FIRE-02');
+      // Simulate an existing closed FIRE-01 issue at #9.
+      fire02.blockedByIssues.add(
+        BlockerRef(id: 'FIRE-01', number: 9, closed: true),
+      );
+      final body = renderBody(fire02);
+      expect(body, contains('Synced from [docs/roadmap.md]'));
+      expect(body, contains('**Metadata**'));
+      expect(body, contains('- Roadmap ID: `FIRE-02`'));
+      expect(body, contains('- Type: `type:infra`'));
+      expect(body, contains('- Roadmap blocked by field: `FIRE-01`'));
+      expect(body, contains('**Description**'));
+      expect(body, contains('**Blocked By**'));
+      expect(body, contains('- [x] #9'));
+    });
+  });
+
+  group('RoadmapEntry.desiredLabels', () {
+    test('emits phase, type, priority, and requires labels', () {
+      final entries = parseRoadmap(_sampleRoadmap);
+      final fire01 = entries.firstWhere((e) => e.id == 'FIRE-01');
+      expect(
+        fire01.desiredLabels(),
+        containsAll(<String>{
+          'phase:1',
+          'type:infra',
+          'priority:p0',
+          'requires:human',
+        }),
+      );
+    });
+  });
+
+  group('extractRoadmapId', () {
+    test('parses prefix from issue titles', () {
+      expect(extractRoadmapId('GUARD-02 — Tighter analyzer rules'), 'GUARD-02');
+      expect(extractRoadmapId('FIRE-12 — Cloud Function'), 'FIRE-12');
+      expect(extractRoadmapId('Random title'), isNull);
+    });
+  });
+
+  group('SyncConfig.fromArgs', () {
+    test('parses defaults', () {
+      final config = SyncConfig.fromArgs(const []);
+      expect(config.dryRun, isFalse);
+      expect(config.roadmapPath, 'docs/roadmap.md');
+    });
+
+    test('parses --dry-run and overrides', () {
+      final config = SyncConfig.fromArgs(const [
+        '--dry-run',
+        '--roadmap',
+        'custom.md',
+        '--repo',
+        'foo/bar',
+      ]);
+      expect(config.dryRun, isTrue);
+      expect(config.roadmapPath, 'custom.md');
+      expect(config.repoSlug, 'foo/bar');
+    });
+
+    test('rejects unknown flags', () {
+      expect(() => SyncConfig.fromArgs(const ['--bogus']), throwsArgumentError);
+    });
+  });
+}

--- a/tool/sync_issues.dart
+++ b/tool/sync_issues.dart
@@ -1,0 +1,600 @@
+// Issue-sync script: parse `docs/roadmap.md` and idempotently mirror each
+// roadmap entry as a GitHub issue with matching labels.
+//
+// Usage:
+//   dart run tool/sync_issues.dart [--dry-run] [--repo <owner>/<repo>]
+//                                  [--roadmap docs/roadmap.md]
+//
+// Requires the `gh` CLI to be authenticated. Re-running without changes is a
+// no-op; bodies, titles, and labels converge on the current roadmap content.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+const _defaultRoadmapPath = 'docs/roadmap.md';
+const _defaultRepoSlug = 'amirorgani/pickllist';
+const _bodyHeader =
+    'Synced from [docs/roadmap.md]'
+    '(https://github.com/amirorgani/pickllist/blob/main/docs/roadmap.md).';
+
+Future<void> main(List<String> args) async {
+  final config = SyncConfig.fromArgs(args);
+  final source = await File(config.roadmapPath).readAsString();
+  final entries = parseRoadmap(source);
+
+  resolveDependencies(entries);
+
+  final github = GitHubClient(repoSlug: config.repoSlug, dryRun: config.dryRun);
+  final existingIssues = await github.listIssues();
+  final existingLabels = await github.listLabelNames();
+
+  final issuesById = <String, GhIssue>{};
+  for (final issue in existingIssues) {
+    final id = extractRoadmapId(issue.title);
+    if (id != null) issuesById[id] = issue;
+  }
+
+  for (final entry in entries) {
+    for (final id in entry.blockedBy) {
+      final blocker = issuesById[id];
+      if (blocker != null) {
+        entry.blockedByIssues.add(
+          BlockerRef(id: id, number: blocker.number, closed: blocker.closed),
+        );
+      }
+    }
+    for (final id in entry.blocks) {
+      final blocked = issuesById[id];
+      if (blocked != null) {
+        entry.blocksIssues.add(blocked.number);
+      }
+    }
+    entry.blockedByIssues.sort((a, b) => a.number.compareTo(b.number));
+    entry.blocksIssues.sort();
+  }
+
+  final desiredLabels = <String>{};
+  for (final entry in entries) {
+    desiredLabels.addAll(entry.desiredLabels());
+  }
+  desiredLabels.add('blocked');
+
+  for (final label in desiredLabels) {
+    if (!existingLabels.contains(label)) {
+      await github.createLabel(label);
+    }
+  }
+
+  for (final entry in entries) {
+    final desiredTitle = '${entry.id} — ${entry.title}';
+    final desiredBody = renderBody(entry);
+    final desiredLabelSet = entry.desiredLabels();
+    if (entry.isBlockedNow()) desiredLabelSet.add('blocked');
+
+    final existing = issuesById[entry.id];
+    if (existing == null) {
+      await github.createIssue(
+        title: desiredTitle,
+        body: desiredBody,
+        labels: desiredLabelSet,
+      );
+      continue;
+    }
+    final existingLabelSet = existing.labels.toSet();
+    final managedExisting = existingLabelSet.where(_isManagedLabel).toSet();
+    final addLabels = desiredLabelSet.difference(existingLabelSet);
+    final removeLabels = managedExisting.difference(desiredLabelSet);
+    final needsTitle = existing.title != desiredTitle;
+    final needsBody = existing.body.trim() != desiredBody.trim();
+    if (!needsTitle &&
+        !needsBody &&
+        addLabels.isEmpty &&
+        removeLabels.isEmpty) {
+      stdout.writeln('= no change: ${existing.number} ${existing.title}');
+      continue;
+    }
+    await github.updateIssue(
+      number: existing.number,
+      title: needsTitle ? desiredTitle : null,
+      body: needsBody ? desiredBody : null,
+      addLabels: addLabels,
+      removeLabels: removeLabels,
+    );
+  }
+}
+
+const _managedLabelPrefixes = <String>[
+  'phase:',
+  'type:',
+  'priority:',
+  'platform:',
+  'requires:',
+];
+
+bool _isManagedLabel(String label) {
+  if (label == 'blocked') return true;
+  return _managedLabelPrefixes.any(label.startsWith);
+}
+
+class SyncConfig {
+  SyncConfig({
+    required this.roadmapPath,
+    required this.repoSlug,
+    required this.dryRun,
+  });
+
+  factory SyncConfig.fromArgs(List<String> args) {
+    var roadmapPath = _defaultRoadmapPath;
+    var repoSlug = _defaultRepoSlug;
+    var dryRun = false;
+    for (var i = 0; i < args.length; i++) {
+      final arg = args[i];
+      switch (arg) {
+        case '--dry-run':
+          dryRun = true;
+        case '--roadmap':
+          roadmapPath = _requireValue(args, ++i, '--roadmap');
+        case '--repo':
+          repoSlug = _requireValue(args, ++i, '--repo');
+        case '--help' || '-h':
+          stdout.writeln(_helpText);
+          exit(0);
+        default:
+          throw ArgumentError('Unknown argument: $arg');
+      }
+    }
+    return SyncConfig(
+      roadmapPath: roadmapPath,
+      repoSlug: repoSlug,
+      dryRun: dryRun,
+    );
+  }
+
+  final String roadmapPath;
+  final String repoSlug;
+  final bool dryRun;
+
+  static String _requireValue(List<String> args, int index, String flag) {
+    if (index >= args.length) {
+      throw ArgumentError('$flag requires a value');
+    }
+    return args[index];
+  }
+}
+
+const _helpText =
+    '''
+Usage: dart run tool/sync_issues.dart [options]
+
+Options:
+  --dry-run         Print intended changes without calling the GitHub API.
+  --repo <slug>     GitHub repository (default: $_defaultRepoSlug).
+  --roadmap <path>  Roadmap file (default: $_defaultRoadmapPath).
+  -h, --help        Show this help.
+''';
+
+class RoadmapEntry {
+  RoadmapEntry({
+    required this.id,
+    required this.title,
+    required this.metadataLines,
+    required this.descriptionLines,
+    required this.acceptanceLines,
+    required this.blockedByRaw,
+    required this.blocksRaw,
+    required this.blockedBy,
+    required this.blocks,
+    required this.requires,
+    required this.type,
+    required this.phase,
+    required this.priority,
+    required this.owner,
+  });
+
+  final String id;
+  final String title;
+  final List<String> metadataLines;
+  final List<String> descriptionLines;
+  final List<String> acceptanceLines;
+  final String? blockedByRaw;
+  final String? blocksRaw;
+  final List<String> blockedBy;
+  final List<String> blocks;
+  final String? requires;
+  final String? type;
+  final String? phase;
+  final String? priority;
+  final String? owner;
+
+  final List<BlockerRef> blockedByIssues = [];
+  final List<int> blocksIssues = [];
+
+  Set<String> desiredLabels() {
+    final labels = <String>{};
+    if (phase != null) labels.add(phase!);
+    if (type != null) labels.add(type!);
+    if (priority != null) labels.add(priority!);
+    if (requires != null) labels.add(_extractRequiresLabel(requires!));
+    final lower = metadataLines.join(' ').toLowerCase();
+    if (lower.contains('platform:mobile')) labels.add('platform:mobile');
+    if (lower.contains('platform:windows')) labels.add('platform:windows');
+    if (lower.contains('platform:all')) labels.add('platform:all');
+    return labels;
+  }
+
+  bool isBlockedNow() {
+    if (blockedByIssues.isEmpty) return false;
+    return blockedByIssues.any((b) => !b.closed);
+  }
+}
+
+String _extractRequiresLabel(String raw) {
+  final match = RegExp(r'`([^`]+)`').firstMatch(raw);
+  return match?.group(1) ?? 'requires:human';
+}
+
+class BlockerRef {
+  BlockerRef({required this.id, required this.number, required this.closed});
+
+  final String id;
+  final int number;
+  final bool closed;
+}
+
+List<RoadmapEntry> parseRoadmap(String source) {
+  final lines = source.split('\n');
+  final headerRegex = RegExp(r'^## `([A-Z]+-\d+)` — (.+)$');
+  final entries = <RoadmapEntry>[];
+  var i = 0;
+  while (i < lines.length) {
+    final match = headerRegex.firstMatch(lines[i]);
+    if (match == null) {
+      i++;
+      continue;
+    }
+    final id = match.group(1)!;
+    final title = match.group(2)!.trim();
+    i++;
+    // skip blank lines
+    while (i < lines.length && lines[i].trim().isEmpty) {
+      i++;
+    }
+    final metadataLines = <String>[];
+    while (i < lines.length && lines[i].startsWith('- **')) {
+      metadataLines.add(lines[i]);
+      i++;
+    }
+    while (i < lines.length && lines[i].trim().isEmpty) {
+      i++;
+    }
+    final descriptionLines = <String>[];
+    final acceptanceLines = <String>[];
+    if (i < lines.length && lines[i].startsWith('**Description.**')) {
+      // collect until **Acceptance criteria:** or next entry
+      final firstLine = lines[i].replaceFirst('**Description.**', '').trim();
+      if (firstLine.isNotEmpty) descriptionLines.add(firstLine);
+      i++;
+      while (i < lines.length &&
+          !lines[i].startsWith('**Acceptance criteria:**') &&
+          !headerRegex.hasMatch(lines[i]) &&
+          !lines[i].startsWith('---') &&
+          !lines[i].startsWith('# ')) {
+        descriptionLines.add(lines[i]);
+        i++;
+      }
+      while (descriptionLines.isNotEmpty &&
+          descriptionLines.last.trim().isEmpty) {
+        descriptionLines.removeLast();
+      }
+    }
+    if (i < lines.length && lines[i].startsWith('**Acceptance criteria:**')) {
+      i++;
+      while (i < lines.length &&
+          !headerRegex.hasMatch(lines[i]) &&
+          !lines[i].startsWith('---') &&
+          !lines[i].startsWith('# ') &&
+          !lines[i].startsWith('**')) {
+        acceptanceLines.add(lines[i]);
+        i++;
+      }
+      while (acceptanceLines.isNotEmpty &&
+          acceptanceLines.last.trim().isEmpty) {
+        acceptanceLines.removeLast();
+      }
+    }
+    final meta = _parseMetadata(metadataLines);
+    entries.add(
+      RoadmapEntry(
+        id: id,
+        title: title,
+        metadataLines: metadataLines,
+        descriptionLines: descriptionLines,
+        acceptanceLines: acceptanceLines,
+        blockedByRaw: meta['blocked by'],
+        blocksRaw: meta['blocks'],
+        blockedBy: <String>[],
+        blocks: <String>[],
+        requires: meta['requires'],
+        type: _normalizeLabel(meta['type'], 'type'),
+        phase: _normalizeLabel(meta['phase'], 'phase'),
+        priority: _normalizeLabel(meta['priority'], 'priority'),
+        owner: meta['owner'],
+      ),
+    );
+  }
+  return entries;
+}
+
+Map<String, String> _parseMetadata(List<String> lines) {
+  final result = <String, String>{};
+  for (final line in lines) {
+    var rest = line.startsWith('- ') ? line.substring(2) : line;
+    final pieces = rest.split(' · ');
+    for (final piece in pieces) {
+      final keyMatch = RegExp(r'^\*\*([^:]+):\*\*\s*(.*)$').firstMatch(piece);
+      if (keyMatch == null) continue;
+      final key = keyMatch.group(1)!.trim().toLowerCase();
+      final value = keyMatch.group(2)!.trim();
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+String? _normalizeLabel(String? raw, String prefix) {
+  if (raw == null) return null;
+  final match = RegExp('`($prefix:[a-z0-9]+)`').firstMatch(raw);
+  return match?.group(1);
+}
+
+void resolveDependencies(List<RoadmapEntry> entries) {
+  final allIds = entries.map((e) => e.id).toList();
+  for (final entry in entries) {
+    final ids = _expandIdList(entry.blockedByRaw, allIds);
+    entry.blockedBy
+      ..clear()
+      ..addAll(ids);
+  }
+  // Compute Blocks reverse graph: any other entry whose Blocked-by contains
+  // this id — but only when the source-of-truth is the explicit Blocks list.
+  for (final entry in entries) {
+    final blocksIds = _expandIdList(entry.blocksRaw, allIds);
+    final reverse = entries
+        .where((other) => other.blockedBy.contains(entry.id))
+        .map((other) => other.id);
+    final union = <String>{...blocksIds, ...reverse};
+    entry.blocks
+      ..clear()
+      ..addAll(union.toList()..sort(_compareIds));
+  }
+}
+
+int _compareIds(String a, String b) {
+  final ra = RegExp(r'^([A-Z]+)-(\d+)$').firstMatch(a);
+  final rb = RegExp(r'^([A-Z]+)-(\d+)$').firstMatch(b);
+  if (ra == null || rb == null) return a.compareTo(b);
+  final prefixCmp = ra.group(1)!.compareTo(rb.group(1)!);
+  if (prefixCmp != 0) return prefixCmp;
+  return int.parse(ra.group(2)!).compareTo(int.parse(rb.group(2)!));
+}
+
+List<String> _expandIdList(String? raw, List<String> allIds) {
+  if (raw == null) return const [];
+  final cleaned = raw.replaceAll('`', '');
+  final tokens = cleaned
+      .split(RegExp(r',|\band\b'))
+      .map((t) => t.trim())
+      .where((t) => t.isNotEmpty);
+  final ids = <String>{};
+  for (final token in tokens) {
+    final wildcardMatch = RegExp(
+      r'([A-Z]+)-\*',
+    ).firstMatch(token.replaceAll('all ', ''));
+    if (wildcardMatch != null) {
+      final prefix = wildcardMatch.group(1)!;
+      ids.addAll(allIds.where((id) => id.startsWith('$prefix-')));
+      continue;
+    }
+    final exact = RegExp(r'([A-Z]+-\d+)').firstMatch(token);
+    if (exact != null) ids.add(exact.group(1)!);
+  }
+  final sorted = ids.toList()..sort(_compareIds);
+  return sorted;
+}
+
+String renderBody(RoadmapEntry entry) {
+  final buffer = StringBuffer()
+    ..writeln(_bodyHeader)
+    ..writeln()
+    ..writeln('**Metadata**')
+    ..writeln('- Roadmap ID: `${entry.id}`');
+  if (entry.type != null) buffer.writeln('- Type: `${entry.type}`');
+  if (entry.phase != null) buffer.writeln('- Phase: `${entry.phase}`');
+  if (entry.priority != null) buffer.writeln('- Priority: `${entry.priority}`');
+  if (entry.requires != null) buffer.writeln('- Requires: ${entry.requires}');
+  if (entry.owner != null) buffer.writeln('- Owner: ${entry.owner}');
+  if (entry.blocksRaw != null) {
+    buffer.writeln('- Roadmap blocks field: ${entry.blocksRaw}');
+  }
+  if (entry.blockedByRaw != null) {
+    buffer.writeln('- Roadmap blocked by field: ${entry.blockedByRaw}');
+  }
+  if (entry.descriptionLines.isNotEmpty) {
+    buffer
+      ..writeln()
+      ..writeln('**Description**');
+    for (final line in entry.descriptionLines) {
+      buffer.writeln(line);
+    }
+  }
+  if (entry.acceptanceLines.isNotEmpty) {
+    buffer
+      ..writeln()
+      ..writeln('**Acceptance Criteria**');
+    for (final line in entry.acceptanceLines) {
+      buffer.writeln(line);
+    }
+  }
+  if (entry.blockedByIssues.isNotEmpty) {
+    buffer
+      ..writeln()
+      ..writeln('**Blocked By**');
+    for (final ref in entry.blockedByIssues) {
+      buffer.writeln('- [${ref.closed ? "x" : " "}] #${ref.number}');
+    }
+  }
+  if (entry.blocksIssues.isNotEmpty) {
+    buffer
+      ..writeln()
+      ..writeln('**Blocks**');
+    for (final n in entry.blocksIssues) {
+      buffer.writeln('- #$n');
+    }
+  }
+  return buffer.toString().trimRight();
+}
+
+String? extractRoadmapId(String title) {
+  final match = RegExp(r'^([A-Z]+-\d+)').firstMatch(title);
+  return match?.group(1);
+}
+
+class GhIssue {
+  GhIssue({
+    required this.number,
+    required this.title,
+    required this.body,
+    required this.labels,
+    required this.closed,
+  });
+
+  final int number;
+  final String title;
+  final String body;
+  final List<String> labels;
+  final bool closed;
+}
+
+class GitHubClient {
+  GitHubClient({required this.repoSlug, required this.dryRun});
+
+  final String repoSlug;
+  final bool dryRun;
+
+  Future<List<GhIssue>> listIssues() async {
+    final raw = await _gh([
+      'issue',
+      'list',
+      '--repo',
+      repoSlug,
+      '--state',
+      'all',
+      '--limit',
+      '500',
+      '--json',
+      'number,title,body,labels,state',
+    ]);
+    final decoded = jsonDecode(raw) as List<dynamic>;
+    return decoded.map((e) {
+      final m = e as Map<String, dynamic>;
+      final labels = (m['labels'] as List<dynamic>)
+          .map((l) => (l as Map<String, dynamic>)['name'] as String)
+          .toList();
+      return GhIssue(
+        number: m['number'] as int,
+        title: m['title'] as String,
+        body: (m['body'] as String?) ?? '',
+        labels: labels,
+        closed: (m['state'] as String).toUpperCase() == 'CLOSED',
+      );
+    }).toList();
+  }
+
+  Future<Set<String>> listLabelNames() async {
+    final raw = await _gh([
+      'label',
+      'list',
+      '--repo',
+      repoSlug,
+      '--limit',
+      '500',
+      '--json',
+      'name',
+    ]);
+    final decoded = jsonDecode(raw) as List<dynamic>;
+    return decoded
+        .map((e) => (e as Map<String, dynamic>)['name'] as String)
+        .toSet();
+  }
+
+  Future<void> createLabel(String name) async {
+    stdout.writeln('+ create label: $name');
+    if (dryRun) return;
+    await _gh(['label', 'create', name, '--repo', repoSlug, '--force']);
+  }
+
+  Future<void> createIssue({
+    required String title,
+    required String body,
+    required Set<String> labels,
+  }) async {
+    stdout.writeln('+ create issue: $title (labels: ${labels.join(",")})');
+    if (dryRun) return;
+    final args = <String>[
+      'issue',
+      'create',
+      '--repo',
+      repoSlug,
+      '--title',
+      title,
+      '--body',
+      body,
+    ];
+    for (final label in labels) {
+      args
+        ..add('--label')
+        ..add(label);
+    }
+    await _gh(args);
+  }
+
+  Future<void> updateIssue({
+    required int number,
+    String? title,
+    String? body,
+    Set<String> addLabels = const <String>{},
+    Set<String> removeLabels = const <String>{},
+  }) async {
+    stdout.writeln(
+      '~ update issue #$number'
+      '${title != null ? " title" : ""}'
+      '${body != null ? " body" : ""}'
+      '${addLabels.isNotEmpty ? " +${addLabels.join(",")}" : ""}'
+      '${removeLabels.isNotEmpty ? " -${removeLabels.join(",")}" : ""}',
+    );
+    if (dryRun) return;
+    final args = <String>['issue', 'edit', '$number', '--repo', repoSlug];
+    if (title != null) args.addAll(['--title', title]);
+    if (body != null) args.addAll(['--body', body]);
+    if (addLabels.isNotEmpty) {
+      args
+        ..add('--add-label')
+        ..add(addLabels.join(','));
+    }
+    if (removeLabels.isNotEmpty) {
+      args
+        ..add('--remove-label')
+        ..add(removeLabels.join(','));
+    }
+    await _gh(args);
+  }
+
+  Future<String> _gh(List<String> args) async {
+    final result = await Process.run('gh', args, stdoutEncoding: utf8);
+    if (result.exitCode != 0) {
+      throw StateError('gh ${args.join(" ")} failed: ${result.stderr}');
+    }
+    return result.stdout as String;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `tool/sync_issues.dart` to mirror each `## \`<ID>\` — Title` entry in `docs/roadmap.md` to a GitHub issue, idempotently. Re-runs converge title, body, and labels to the roadmap; matching key is the roadmap ID prefix in the title.
- Resolve `Blocked by` (with `*` wildcards) and `Blocks` into the live issue numbers. Toggle the `blocked` label based on whether all blockers are closed.
- `--dry-run`, `--repo`, and `--roadmap` flags. Uses the local `gh` CLI so no extra auth wiring is needed.
- Tests cover parsing, dependency resolution, body rendering, and CLI parsing.
- Documented in `docs/setup.md`.

## Issue

Closes #44

## Self CR

- Commands run:
  - `flutter pub get`
  - `dart format --set-exit-if-changed .`
  - `flutter analyze --fatal-infos` — clean
  - `flutter test --coverage` — 52 tests pass
  - `dart run tool/check_coverage.dart --base origin/main --head HEAD` — coverage 40.16% holds at baseline
  - `dart run tool/sync_issues.dart --dry-run` — exercises the live roadmap end-to-end
- Issues found and fixed during self CR:
  - First pass used a single `--add-label` call which never removed stale labels (e.g. `blocked` on a now-unblocked issue). Switched the update path to compute add/remove sets against a managed-label allowlist (`phase:`, `type:`, `priority:`, `platform:`, `requires:`, `blocked`) so non-managed labels (e.g. `good-first-ai-task`) are left alone.
  - Initial parser passed `const []` for `blockedBy` / `blocks`; `resolveDependencies` mutates them, which crashed on unmodifiable lists. Fixed to mutable lists; tests cover the path.
- Residual risks:
  - Body format hand-matches the existing issue corpus. The first real run (post-merge) may rewrite a number of bodies to converge on the canonical formatter; subsequent runs are no-ops. Verified via `--dry-run`: a meaningful subset of issues already report `= no change`, the rest are body or label diffs caused by the script's reverse-`Blocks` resolution and managed-label cleanup.
  - The script changes only `tool/`, `test/tool/`, and `docs/setup.md`; no `lib/` impact, so the Firebase/localization/platform-gating gates are not exercised.

## Test plan

- [x] `flutter analyze --fatal-infos`
- [x] `flutter test --coverage`
- [x] `dart run tool/sync_issues.dart --dry-run` succeeds end-to-end against the current repo
- [ ] Post-merge: run `dart run tool/sync_issues.dart` once on `main` to converge existing issues, then verify a second run prints all `= no change`

🤖 Generated with [Claude Code](https://claude.com/claude-code)