### PR TITLE
feat: add public API surface snapshot guardrail

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -17,3 +17,22 @@ The check compares `coverage/lcov.info` against the committed baseline in
 The ratchet only moves upward through an explicit PR change to
 `tool/coverage_baseline.json`. When `main` improves, update that file in the
 same PR as the improvement so future PRs cannot regress below the new level.
+
+## Public API surface snapshot
+
+`test/api_surface_test.dart` walks every `.dart` file under `lib/`, extracts
+each public top-level declaration (`class`, `enum`, `mixin`, `extension`,
+`typedef`), and compares the rendered surface to the committed snapshot at
+`test/api_surface.snapshot.txt`.
+
+If a PR adds, renames, or removes a public symbol, the test fails. The fix is
+to regenerate and commit the snapshot in the same PR — that turns silent API
+churn into a deliberate, reviewable change:
+
+```sh
+dart run tool/generate_api_snapshot.dart --write
+```
+
+Generated files (`*.g.dart`, `*.freezed.dart`, `lib/l10n/generated/`,
+`lib/firebase_options.dart`) are excluded from the snapshot — they regenerate
+deterministically and would only add noise.

--- a/test/api_surface.snapshot.txt
+++ b/test/api_surface.snapshot.txt
@@ -1,0 +1,22 @@
+lib/app.dart::class PickllistApp
+lib/core/platform/platform_info.dart::class PlatformInfo
+lib/core/theme/app_theme.dart::class AppTheme
+lib/features/auth/data/auth_repository.dart::abstract class AuthRepository
+lib/features/auth/data/auth_repository.dart::class AuthException
+lib/features/auth/data/fake_auth_repository.dart::class FakeAuthRepository
+lib/features/auth/domain/app_user.dart::class AppUser
+lib/features/auth/domain/app_user.dart::enum UserRole
+lib/features/auth/domain/app_user.dart::extension AppUserListX
+lib/features/auth/presentation/login_screen.dart::class LoginScreen
+lib/features/picking_lists/data/fake_picking_list_repository.dart::class FakePickingListRepository
+lib/features/picking_lists/data/picking_list_repository.dart::abstract class PickingListRepository
+lib/features/picking_lists/data/picking_list_repository.dart::class RepositoryException
+lib/features/picking_lists/domain/picking_item.dart::class PickingItem
+lib/features/picking_lists/domain/picking_list.dart::class PickingList
+lib/features/picking_lists/domain/picking_list.dart::enum PickingListStatus
+lib/features/picking_lists/domain/quantity_unit.dart::enum QuantityUnit
+lib/features/picking_lists/presentation/picking_list_detail_screen.dart::class PickingListDetailScreen
+lib/features/picking_lists/presentation/picking_lists_screen.dart::class PickingListsScreen
+lib/features/picking_lists/presentation/widgets/picking_item_tile.dart::class PickingItemTile
+lib/features/users/data/fake_user_directory_repository.dart::class FakeUserDirectoryRepository
+lib/features/users/data/user_directory_repository.dart::abstract class UserDirectoryRepository

--- a/test/api_surface_test.dart
+++ b/test/api_surface_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../tool/generate_api_snapshot.dart';
+
+void main() {
+  test('public API matches committed snapshot', () async {
+    final symbols = await collectPublicApi(libDir: defaultLibDir);
+    final actual = renderSnapshot(symbols);
+    final expected = await File(defaultSnapshotPath).readAsString();
+    if (actual != expected) {
+      fail(
+        'Public API surface diverged from $defaultSnapshotPath.\n'
+        'If the change is intentional, regenerate and commit the new '
+        'snapshot in the same PR:\n'
+        '  dart run tool/generate_api_snapshot.dart --write\n'
+        'Diff (expected vs actual):\n'
+        '${_renderDiff(expected: expected, actual: actual)}',
+      );
+    }
+  });
+
+  group('extractSymbols', () {
+    test('captures the canonical declaration keywords', () {
+      final source = '''
+class Foo {}
+abstract class Bar {}
+sealed class Baz {}
+final class Qux extends Foo {}
+mixin Mixed on Foo {}
+mixin class HybridMixin {}
+enum Color { red, green }
+extension OnFoo on Foo { void m() {} }
+typedef Callback = void Function(int);
+class _Private {}
+''';
+      final symbols = extractSymbols(source: source, path: 'lib/sample.dart');
+      final declarations = symbols.map((s) => s.declaration).toList();
+      expect(declarations, contains('class Foo'));
+      expect(declarations, contains('abstract class Bar'));
+      expect(declarations, contains('sealed class Baz'));
+      expect(declarations, contains('final class Qux'));
+      expect(declarations, contains('mixin Mixed'));
+      expect(declarations, contains('mixin class HybridMixin'));
+      expect(declarations, contains('enum Color'));
+      expect(declarations, contains('extension OnFoo'));
+      expect(declarations, contains('typedef Callback'));
+      expect(
+        declarations.where((d) => d.contains('_Private')),
+        isEmpty,
+        reason: 'Private declarations must not enter the surface snapshot.',
+      );
+    });
+
+    test('strips inheritance, generics, and trailing braces', () {
+      final source = '''
+class Generic<T extends Object?> with Mixed implements Foo {}
+class WithBody { void m() {} }
+''';
+      final symbols = extractSymbols(source: source, path: 'lib/x.dart');
+      final declarations = symbols.map((s) => s.declaration).toSet();
+      expect(declarations.contains('class Generic'), isTrue);
+      expect(declarations.contains('class WithBody'), isTrue);
+    });
+
+    test('ignores comments and indented declarations', () {
+      final source = '''
+// class CommentedOut {}
+   class Indented {}
+''';
+      final symbols = extractSymbols(source: source, path: 'lib/x.dart');
+      expect(symbols, isEmpty);
+    });
+  });
+
+  group('renderSnapshot', () {
+    test('sorts symbols alphabetically by their full line', () {
+      final unsorted = [
+        ApiSymbol(path: 'lib/b.dart', declaration: 'class B'),
+        ApiSymbol(path: 'lib/a.dart', declaration: 'class Z'),
+        ApiSymbol(path: 'lib/a.dart', declaration: 'class A'),
+      ];
+      final rendered = renderSnapshot(unsorted);
+      expect(
+        rendered,
+        'lib/a.dart::class A\n'
+        'lib/a.dart::class Z\n'
+        'lib/b.dart::class B\n',
+      );
+    });
+  });
+}
+
+String _renderDiff({required String expected, required String actual}) {
+  final expectedLines = expected.split('\n').toSet();
+  final actualLines = actual.split('\n').toSet();
+  final removed = expectedLines.difference(actualLines).toList()..sort();
+  final added = actualLines.difference(expectedLines).toList()..sort();
+  final buffer = StringBuffer();
+  for (final line in removed) {
+    if (line.isEmpty) continue;
+    buffer.writeln('- $line');
+  }
+  for (final line in added) {
+    if (line.isEmpty) continue;
+    buffer.writeln('+ $line');
+  }
+  return buffer.toString();
+}

--- a/tool/generate_api_snapshot.dart
+++ b/tool/generate_api_snapshot.dart
@@ -1,0 +1,156 @@
+// Public API surface snapshot generator.
+//
+// Walks `lib/`, extracts every public top-level declaration (class, enum,
+// mixin, extension, typedef), and writes a sorted snapshot to
+// `test/api_surface.snapshot.txt`.
+//
+// Run with `--write` to update the committed snapshot. Without flags, prints
+// the snapshot to stdout — useful for inspecting drift before committing.
+//
+// `test/api_surface_test.dart` enforces parity by comparing the live surface
+// to the committed snapshot.
+
+import 'dart:io';
+
+const defaultLibDir = 'lib';
+const defaultSnapshotPath = 'test/api_surface.snapshot.txt';
+
+Future<void> main(List<String> args) async {
+  final write = args.contains('--write');
+  final symbols = await collectPublicApi(libDir: defaultLibDir);
+  final content = renderSnapshot(symbols);
+  if (write) {
+    await File(defaultSnapshotPath).writeAsString(content);
+    stdout.writeln('Wrote ${symbols.length} symbols to $defaultSnapshotPath.');
+    return;
+  }
+  stdout.write(content);
+}
+
+class ApiSymbol implements Comparable<ApiSymbol> {
+  ApiSymbol({required this.path, required this.declaration});
+
+  final String path;
+  final String declaration;
+
+  String get line => '$path::$declaration';
+
+  @override
+  int compareTo(ApiSymbol other) => line.compareTo(other.line);
+
+  @override
+  bool operator ==(Object other) =>
+      other is ApiSymbol &&
+      other.path == path &&
+      other.declaration == declaration;
+
+  @override
+  int get hashCode => Object.hash(path, declaration);
+}
+
+String renderSnapshot(List<ApiSymbol> symbols) {
+  final sorted = [...symbols]..sort();
+  final buffer = StringBuffer();
+  for (final symbol in sorted) {
+    buffer.writeln(symbol.line);
+  }
+  return buffer.toString();
+}
+
+Future<List<ApiSymbol>> collectPublicApi({required String libDir}) async {
+  final root = Directory(libDir);
+  if (!await root.exists()) {
+    throw StateError('lib directory not found at $libDir');
+  }
+  final symbols = <ApiSymbol>[];
+  await for (final entity in root.list(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.dart')) continue;
+    final relative = entity.path.replaceAll('\\', '/');
+    if (_isExcluded(relative)) continue;
+    final source = await entity.readAsString();
+    symbols.addAll(extractSymbols(source: source, path: relative));
+  }
+  return symbols;
+}
+
+bool _isExcluded(String path) {
+  if (path.endsWith('.g.dart')) return true;
+  if (path.endsWith('.freezed.dart')) return true;
+  if (path.endsWith('.gr.dart')) return true;
+  if (path.contains('/l10n/generated/')) return true;
+  if (path.endsWith('firebase_options.dart')) return true;
+  return false;
+}
+
+final _patterns = <RegExp>[
+  RegExp(
+    r'^(?:abstract\s+|sealed\s+|base\s+|interface\s+|final\s+|mixin\s+)*'
+    r'class\s+([A-Z][A-Za-z0-9_]*)',
+  ),
+  RegExp(r'^mixin\s+([A-Z][A-Za-z0-9_]*)\b'),
+  RegExp(r'^enum\s+([A-Z][A-Za-z0-9_]*)\b'),
+  RegExp(r'^extension\s+([A-Z][A-Za-z0-9_]*)\b'),
+  RegExp(r'^typedef\s+([A-Z][A-Za-z0-9_]*)\b'),
+];
+
+List<ApiSymbol> extractSymbols({required String source, required String path}) {
+  final results = <ApiSymbol>[];
+  final lines = source.split('\n');
+  for (final raw in lines) {
+    final line = raw.trimRight();
+    if (line.isEmpty || line.startsWith('//')) continue;
+    if (!_isLikelyDeclaration(line)) continue;
+    final declaration = _normaliseDeclaration(line);
+    if (declaration == null) continue;
+    if (!_patterns.any((p) => p.hasMatch(declaration))) continue;
+    results.add(ApiSymbol(path: path, declaration: declaration));
+  }
+  return results;
+}
+
+bool _isLikelyDeclaration(String line) {
+  return line.startsWith('abstract ') ||
+      line.startsWith('sealed ') ||
+      line.startsWith('base ') ||
+      line.startsWith('interface ') ||
+      line.startsWith('final class') ||
+      line.startsWith('mixin ') ||
+      line.startsWith('class ') ||
+      line.startsWith('enum ') ||
+      line.startsWith('extension ') ||
+      line.startsWith('typedef ');
+}
+
+String? _normaliseDeclaration(String line) {
+  // Trim trailing `{`, `extends ...`, `implements ...`, generics, `with ...`.
+  // We keep the keyword + name only so the snapshot stays readable.
+  final stripIndex = _firstIndexOfAny(line, const [
+    ' extends ',
+    ' implements ',
+    ' with ',
+    ' on ',
+    '{',
+    '<',
+    '=',
+  ]);
+  final stripped = stripIndex < 0
+      ? line.trimRight()
+      : line.substring(0, stripIndex).trimRight();
+  final tokens = stripped.split(RegExp(r'\s+'));
+  if (tokens.isEmpty) return null;
+  final name = tokens.last;
+  if (name.startsWith('_')) return null;
+  if (!RegExp(r'^[A-Z][A-Za-z0-9_]*$').hasMatch(name)) return null;
+  return stripped;
+}
+
+int _firstIndexOfAny(String haystack, List<String> needles) {
+  var earliest = -1;
+  for (final needle in needles) {
+    final idx = haystack.indexOf(needle);
+    if (idx < 0) continue;
+    if (earliest < 0 || idx < earliest) earliest = idx;
+  }
+  return earliest;
+}


### PR DESCRIPTION
## Summary

- Add `tool/generate_api_snapshot.dart` to extract every public top-level declaration in `lib/` (classes, enums, mixins, extensions, typedefs).
- Commit the initial snapshot at `test/api_surface.snapshot.txt` (22 symbols).
- Add `test/api_surface_test.dart` to enforce parity against the snapshot and print a `+/-` diff on failure with the exact regenerate command.
- Document the rule and fix-up flow in `docs/guardrails.md`.

Generated files (`*.g.dart`, `*.freezed.dart`, `lib/l10n/generated/`, `lib/firebase_options.dart`) are excluded so deterministic regenerations don't churn the snapshot.

## Issue

Closes #7

## Self CR

- Commands run:
  - `flutter pub get`
  - `dart format --set-exit-if-changed .`
  - `flutter analyze --fatal-infos` — clean
  - `flutter test --coverage` — 57 tests pass
  - `dart run tool/check_coverage.dart --base origin/main --head HEAD` — 40.16% holds
  - `dart run tool/generate_api_snapshot.dart --write` — snapshot matches the committed file (re-running is a no-op)
- Issues found and fixed during self CR:
  - First version of the regex matched `final class` only when written exactly that way; tightened the keyword set to also accept `sealed`, `base`, `interface`, and `mixin class`. Added a unit test that exercises every supported keyword.
  - Walking `lib/` returns OS-native paths on Windows; normalised to forward slashes so the snapshot is stable across platforms (CI runs on Linux + Windows).
  - Excluded `lib/firebase_options.dart` because `flutterfire configure` regenerates it deterministically; without the exclusion every config refresh would touch the snapshot.
- Residual risks:
  - The extractor is regex-based, not AST-based, so multi-line declarations (e.g. `class Foo` on one line, `extends Bar` on the next) still work but a class declared inside a triple-quoted string would technically appear in the snapshot. We don't have any of those today; the trade-off keeps the tool dependency-free instead of pulling in `package:analyzer`.
  - The snapshot lives at `test/api_surface.snapshot.txt`, which test runners ignore as a non-test file (verified via `flutter test --coverage`).

## Test plan

- [x] `flutter test --coverage` (the new `api_surface_test.dart` suite is part of the run)
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/generate_api_snapshot.dart --write` produces no diff
- [ ] Post-merge: future PRs adding/renaming/removing a public symbol must regenerate the snapshot — manually verified by adding a sentinel class locally; the test fails with the expected `+`/`-` diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)