### PR TITLE
feat: add assertion-quality smoke check guardrail (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Static analysis
         run: flutter analyze --fatal-infos
 
+      - name: Check assertion quality
+        run: dart run tool/check_assertion_quality.dart
+
       - name: Generate localizations
         run: flutter gen-l10n
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -18,6 +18,30 @@ The ratchet only moves upward through an explicit PR change to
 `tool/coverage_baseline.json`. When `main` improves, update that file in the
 same PR as the improvement so future PRs cannot regress below the new level.
 
+## Assertion quality
+
+Coverage alone lets shallow tests slip through — `expect(thing, isNotNull)`
+covers the line without proving any meaningful behaviour. CI runs
+`dart run tool/check_assertion_quality.dart` as part of the analyze job and
+fails when the ratio of weak truthy matchers (`isNotNull`, `isNotEmpty`,
+`isTrue`) exceeds 30% of the `expect(...)` calls in a single file.
+
+The default scope is `test/features/picking_lists/`, the GUARD-05 critical
+module. Pass explicit paths to widen the scan locally:
+
+```sh
+# Default scope (also what CI runs).
+dart run tool/check_assertion_quality.dart
+
+# Whole suite.
+dart run tool/check_assertion_quality.dart test/
+```
+
+Files with fewer than 3 `expect(...)` calls are skipped — the ratio is too
+noisy to be useful below that. When the check fails, the fix is to replace
+weak assertions with assertions on specific values (e.g. `equals(...)`,
+`hasLength(...)`, `containsAll([...])`) rather than raising the threshold.
+
 ## Public API surface snapshot
 
 `test/api_surface_test.dart` walks every `.dart` file under `lib/`, extracts

--- a/test/tool/check_assertion_quality_test.dart
+++ b/test/tool/check_assertion_quality_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/check_assertion_quality.dart';
+
+void main() {
+  group('analyseSource', () {
+    test('counts every matcher and flags truthy ones', () {
+      const source = '''
+expect(value, equals(42));
+expect(thing, isNotNull);
+expect(things, isNotEmpty);
+expect(flag, isTrue);
+expect(other, isFalse);
+''';
+      final result = analyseSource(
+        source: source,
+        path: 'test/sample_test.dart',
+      );
+      expect(result.totalExpects, 5);
+      expect(result.truthyCount, 3);
+    });
+
+    test('handles multi-line expect calls', () {
+      const source = '''
+expect(
+  computeResult(),
+  isNotNull,
+);
+expect(
+  computeResult(),
+  equals(42),
+);
+''';
+      final result = analyseSource(
+        source: source,
+        path: 'test/sample_test.dart',
+      );
+      expect(result.totalExpects, 2);
+      expect(result.truthyCount, 1);
+    });
+
+    test('ignores expects inside comments and string literals', () {
+      const source = r'''
+// expect(buried, isTrue);
+final s = "expect(also, isTrue)";
+expect(real, equals(1));
+''';
+      final result = analyseSource(
+        source: source,
+        path: 'test/sample_test.dart',
+      );
+      expect(result.totalExpects, 1);
+      expect(result.truthyCount, 0);
+    });
+
+    test('counts expectLater calls', () {
+      const source = '''
+expectLater(stream, emits('hi'));
+expectLater(future, completes);
+''';
+      final result = analyseSource(
+        source: source,
+        path: 'test/sample_test.dart',
+      );
+      expect(result.totalExpects, 2);
+      expect(result.truthyCount, 0);
+    });
+
+    test('strips matcher arguments before classifying', () {
+      const source = '''
+expect(map, isNotEmpty);
+expect(map, isA<Map<String, int>>());
+''';
+      final result = analyseSource(
+        source: source,
+        path: 'test/sample_test.dart',
+      );
+      expect(result.totalExpects, 2);
+      // isNotEmpty is the only weak truthy matcher; isA<...> is specific.
+      expect(result.truthyCount, 1);
+    });
+  });
+
+  group('analyseFiles', () {
+    test('flags files exceeding the threshold above the min-expects floor', () {
+      final files = [
+        FileSource(
+          path: 'test/strong_test.dart',
+          source: '''
+expect(a, equals(1));
+expect(b, equals(2));
+expect(c, equals(3));
+expect(d, isTrue);
+''',
+        ),
+        FileSource(
+          path: 'test/weak_test.dart',
+          source: '''
+expect(a, isNotNull);
+expect(b, isNotEmpty);
+expect(c, isTrue);
+expect(d, isNotNull);
+''',
+        ),
+      ];
+      final report = analyseFiles(files: files, threshold: 0.30, minExpects: 3);
+      expect(report.summaries, hasLength(2));
+      expect(
+        report.failures.map((f) => f.path),
+        contains('test/weak_test.dart'),
+      );
+      expect(
+        report.failures.map((f) => f.path),
+        isNot(contains('test/strong_test.dart')),
+      );
+    });
+
+    test('skips files below the min-expects floor', () {
+      final files = [
+        FileSource(
+          path: 'test/tiny_test.dart',
+          source: 'expect(value, isNotNull);\n',
+        ),
+      ];
+      final report = analyseFiles(files: files, threshold: 0.30, minExpects: 3);
+      expect(report.failures, isEmpty);
+    });
+  });
+
+  group('AssertionCheckConfig.fromArgs', () {
+    test('parses defaults', () {
+      final config = AssertionCheckConfig.fromArgs(const []);
+      expect(config.threshold, 0.30);
+      expect(config.minExpects, 3);
+      expect(config.paths, isNotEmpty);
+    });
+
+    test('parses overrides and explicit paths', () {
+      final config = AssertionCheckConfig.fromArgs(const [
+        '--threshold',
+        '0.5',
+        '--min-expects',
+        '5',
+        'test/foo/',
+        'test/bar_test.dart',
+      ]);
+      expect(config.threshold, 0.5);
+      expect(config.minExpects, 5);
+      expect(config.paths, ['test/foo/', 'test/bar_test.dart']);
+    });
+
+    test('rejects unknown flags', () {
+      expect(
+        () => AssertionCheckConfig.fromArgs(const ['--bogus']),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('truthyMatchers', () {
+    test('contains exactly the three weak matchers from the spec', () {
+      expect(truthyMatchers, {'isNotNull', 'isNotEmpty', 'isTrue'});
+    });
+  });
+}

--- a/tool/check_assertion_quality.dart
+++ b/tool/check_assertion_quality.dart
@@ -1,0 +1,296 @@
+// Assertion-quality smoke check (GUARD-05).
+//
+// Coverage alone lets shallow tests slip through — `expect(x, isNotNull)`
+// every line covers the code without proving any meaningful behaviour. This
+// script walks test files and fails when the ratio of weak truthy matchers
+// (`isNotNull`, `isNotEmpty`, `isTrue`) exceeds the configured threshold of
+// all `expect(...)` calls in a file.
+//
+// Usage:
+//   dart run tool/check_assertion_quality.dart [--threshold 0.3]
+//                                              [--min-expects 3]
+//                                              [path1 path2 ...]
+//
+// Default scope is `test/features/picking_lists/`, matching the acceptance
+// criteria of GUARD-05; pass explicit paths to widen the scan (or `test/`
+// for the whole suite).
+
+import 'dart:io';
+
+const _defaultThreshold = 0.30;
+const _defaultMinExpects = 3;
+const _defaultPaths = <String>['test/features/picking_lists/'];
+const truthyMatchers = <String>{'isNotNull', 'isNotEmpty', 'isTrue'};
+
+Future<void> main(List<String> args) async {
+  final config = AssertionCheckConfig.fromArgs(args);
+  final files = await _collectTestFiles(config.paths);
+  final report = analyseFiles(
+    files: await _readAll(files),
+    threshold: config.threshold,
+    minExpects: config.minExpects,
+  );
+  for (final summary in report.summaries) {
+    final pct = (summary.truthyRatio * 100).toStringAsFixed(1);
+    stdout.writeln(
+      '${summary.path}: ${summary.truthyCount}/${summary.totalExpects}'
+      ' truthy ($pct%)',
+    );
+  }
+  if (report.failures.isEmpty) {
+    stdout.writeln(
+      '\nAll scanned files keep weak matchers under '
+      '${(config.threshold * 100).toStringAsFixed(0)}%.',
+    );
+    return;
+  }
+  stderr.writeln('\nAssertion-quality failures:');
+  for (final failure in report.failures) {
+    final pct = (failure.truthyRatio * 100).toStringAsFixed(1);
+    stderr.writeln(
+      '  ${failure.path}: ${failure.truthyCount}/${failure.totalExpects}'
+      ' truthy assertions ($pct%) — replace some with assertions on '
+      'specific values.',
+    );
+  }
+  exitCode = 1;
+}
+
+class AssertionCheckConfig {
+  AssertionCheckConfig({
+    required this.threshold,
+    required this.minExpects,
+    required this.paths,
+  });
+
+  factory AssertionCheckConfig.fromArgs(List<String> args) {
+    var threshold = _defaultThreshold;
+    var minExpects = _defaultMinExpects;
+    final paths = <String>[];
+    for (var i = 0; i < args.length; i++) {
+      final arg = args[i];
+      switch (arg) {
+        case '--threshold':
+          threshold = double.parse(_requireValue(args, ++i, '--threshold'));
+        case '--min-expects':
+          minExpects = int.parse(_requireValue(args, ++i, '--min-expects'));
+        case '--help' || '-h':
+          stdout.writeln(_buildHelpText());
+          exit(0);
+        default:
+          if (arg.startsWith('--')) {
+            throw ArgumentError('Unknown flag: $arg');
+          }
+          paths.add(arg);
+      }
+    }
+    return AssertionCheckConfig(
+      threshold: threshold,
+      minExpects: minExpects,
+      paths: paths.isEmpty ? _defaultPaths : paths,
+    );
+  }
+
+  final double threshold;
+  final int minExpects;
+  final List<String> paths;
+
+  static String _requireValue(List<String> args, int index, String flag) {
+    if (index >= args.length) {
+      throw ArgumentError('$flag requires a value');
+    }
+    return args[index];
+  }
+}
+
+String _buildHelpText() =>
+    'Usage: dart run tool/check_assertion_quality.dart [options] [paths...]\n'
+    '\n'
+    'Options:\n'
+    '  --threshold <fraction>  Maximum truthy-assertion ratio (default: 0.3).\n'
+    '  --min-expects <count>   Skip files with fewer expects (default: 3).\n'
+    '  -h, --help              Show this help.\n'
+    '\n'
+    'Truthy matchers tracked: ${truthyMatchers.join(', ')}.\n'
+    'Default scope (when no paths are passed): ${_defaultPaths.join(', ')}.\n';
+
+class FileAnalysis {
+  FileAnalysis({
+    required this.path,
+    required this.totalExpects,
+    required this.truthyCount,
+  });
+
+  final String path;
+  final int totalExpects;
+  final int truthyCount;
+
+  double get truthyRatio => totalExpects == 0 ? 0 : truthyCount / totalExpects;
+}
+
+class AssertionReport {
+  AssertionReport({required this.summaries, required this.failures});
+
+  final List<FileAnalysis> summaries;
+  final List<FileAnalysis> failures;
+}
+
+class FileSource {
+  FileSource({required this.path, required this.source});
+
+  final String path;
+  final String source;
+}
+
+Future<List<FileSource>> _readAll(List<File> files) async {
+  final out = <FileSource>[];
+  for (final file in files) {
+    final source = await file.readAsString();
+    out.add(FileSource(path: file.path.replaceAll('\\', '/'), source: source));
+  }
+  return out;
+}
+
+AssertionReport analyseFiles({
+  required List<FileSource> files,
+  required double threshold,
+  required int minExpects,
+}) {
+  final summaries = <FileAnalysis>[];
+  final failures = <FileAnalysis>[];
+  for (final file in files) {
+    final analysis = analyseSource(source: file.source, path: file.path);
+    summaries.add(analysis);
+    if (analysis.totalExpects >= minExpects &&
+        analysis.truthyRatio > threshold) {
+      failures.add(analysis);
+    }
+  }
+  summaries.sort((a, b) => a.path.compareTo(b.path));
+  return AssertionReport(summaries: summaries, failures: failures);
+}
+
+FileAnalysis analyseSource({required String source, required String path}) {
+  final stripped = _stripCommentsAndStrings(source);
+  final matchers = _collectMatchers(stripped);
+  var truthy = 0;
+  for (final matcher in matchers) {
+    if (truthyMatchers.contains(matcher)) truthy++;
+  }
+  return FileAnalysis(
+    path: path,
+    totalExpects: matchers.length,
+    truthyCount: truthy,
+  );
+}
+
+List<String> _collectMatchers(String source) {
+  final matchers = <String>[];
+  final pattern = RegExp(r'\bexpect(?:Later)?\s*\(');
+  for (final match in pattern.allMatches(source)) {
+    final start = match.end;
+    final args = _splitTopLevelArgs(source, start);
+    if (args.length < 2) continue;
+    final matcher = args[1].trim();
+    final identifier = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*').firstMatch(matcher);
+    matchers.add(identifier?.group(0) ?? matcher);
+  }
+  return matchers;
+}
+
+List<String> _splitTopLevelArgs(String source, int start) {
+  final args = <String>[];
+  final buffer = StringBuffer();
+  var depth = 1;
+  for (var i = start; i < source.length; i++) {
+    final ch = source[i];
+    if (ch == '(' || ch == '[' || ch == '{' || ch == '<') {
+      depth++;
+      buffer.write(ch);
+    } else if (ch == ')' || ch == ']' || ch == '}' || ch == '>') {
+      depth--;
+      if (depth == 0) {
+        if (buffer.isNotEmpty) args.add(buffer.toString());
+        return args;
+      }
+      buffer.write(ch);
+    } else if (ch == ',' && depth == 1) {
+      args.add(buffer.toString());
+      buffer.clear();
+    } else {
+      buffer.write(ch);
+    }
+  }
+  return args;
+}
+
+String _stripCommentsAndStrings(String source) {
+  final buffer = StringBuffer();
+  var i = 0;
+  while (i < source.length) {
+    final ch = source[i];
+    if (ch == '/' && i + 1 < source.length && source[i + 1] == '/') {
+      while (i < source.length && source[i] != '\n') {
+        i++;
+      }
+      continue;
+    }
+    if (ch == '/' && i + 1 < source.length && source[i + 1] == '*') {
+      i += 2;
+      while (i + 1 < source.length &&
+          !(source[i] == '*' && source[i + 1] == '/')) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    if (ch == "'" || ch == '"') {
+      final quote = ch;
+      final triple =
+          i + 2 < source.length &&
+          source[i + 1] == quote &&
+          source[i + 2] == quote;
+      if (triple) {
+        i += 3;
+        while (i + 2 < source.length &&
+            !(source[i] == quote &&
+                source[i + 1] == quote &&
+                source[i + 2] == quote)) {
+          i++;
+        }
+        i += 3;
+        continue;
+      }
+      i++;
+      while (i < source.length && source[i] != quote) {
+        if (source[i] == '\\' && i + 1 < source.length) i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    buffer.write(ch);
+    i++;
+  }
+  return buffer.toString();
+}
+
+Future<List<File>> _collectTestFiles(List<String> paths) async {
+  final files = <File>[];
+  for (final raw in paths) {
+    final entity = FileSystemEntity.typeSync(raw);
+    if (entity == FileSystemEntityType.file) {
+      files.add(File(raw));
+      continue;
+    }
+    if (entity == FileSystemEntityType.directory) {
+      await for (final f in Directory(raw).list(recursive: true)) {
+        if (f is File && f.path.endsWith('_test.dart')) files.add(f);
+      }
+      continue;
+    }
+    throw StateError('Path not found: $raw');
+  }
+  files.sort((a, b) => a.path.compareTo(b.path));
+  return files;
+}


### PR DESCRIPTION
## Summary
- Adds `tool/check_assertion_quality.dart`, an offline smoke check that flags test files whose ratio of weak truthy matchers (`isNotNull`, `isNotEmpty`, `isTrue`) exceeds 30% of `expect(...)` calls. Files with fewer than 3 expects are skipped.
- Wires the check into the `Analyze & test` CI job (between static analysis and localizations).
- Documents the rule in `docs/guardrails.md` alongside the coverage ratchet and API surface snapshot.

Closes #5.

## Why this guardrail
Coverage alone lets shallow tests slip through — `expect(x, isNotNull)` proves a line ran without proving any meaningful behaviour. GUARD-05 keeps a quick, deterministic floor on assertion quality so the coverage ratchet does not get gamed by truthy filler.

## Implementation notes
- Regex-based scanner: matches `expect(` / `expectLater(` after stripping comments and string literals, then walks parens to support multi-line expects and matchers like `isA<Map<String, int>>()`.
- Default scope is `test/features/picking_lists/` (GUARD-05's critical module). CLI accepts custom paths and `--threshold`/`--min-expects` overrides for local exploration.
- Public `analyseSource` / `analyseFiles` / `FileSource` / `AssertionCheckConfig` exposed for unit tests.
- 11 new tests in `test/tool/check_assertion_quality_test.dart` cover matcher counting, multi-line expects, comment/string stripping, `expectLater`, generic matcher arg stripping, threshold/floor flagging, and config parsing.

## Self CR
- Verified `dart format --set-exit-if-changed .` clean.
- `flutter analyze --fatal-infos` — no issues.
- `flutter test --coverage` — 68 tests pass (11 new).
- `dart run tool/check_assertion_quality.dart` — both picking_lists test files report under 30% truthy ratio.
- Considered widening default scope to `test/`; deferred because `test/firebase_options_test.dart` is at 50% truthy ratio (legitimate `isNotEmpty` checks against Firebase config strings) and would need a refactor outside GUARD-05's scope.

## Test plan
- [x] `flutter analyze --fatal-infos`
- [x] `flutter test --coverage`
- [x] `dart run tool/check_assertion_quality.dart`
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)