### PR TITLE
feat: add architectural fitness tests guardrail (#3)

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -42,6 +42,34 @@ noisy to be useful below that. When the check fails, the fix is to replace
 weak assertions with assertions on specific values (e.g. `equals(...)`,
 `hasLength(...)`, `containsAll([...])`) rather than raising the threshold.
 
+## Architectural fitness tests
+
+`test/architecture/` parses source files and asserts layering invariants
+that are easy to violate accidentally and expensive to unwind later.
+Each rule lives in its own test file so failures point at exactly which
+invariant slipped:
+
+- **`layer_boundaries_test.dart`** — `lib/features/*/domain/` may import
+  only other domain files, `package:collection`, or `dart:*`; data files
+  must not depend on presentation; presentation files may not reach into
+  another feature's `data/` directly (collaborate via `application/`).
+- **`file_size_test.dart`** — no hand-written file under `lib/` may
+  exceed 400 significant lines (blank lines and comments excluded).
+  Generated files (`*.g.dart`, `*.freezed.dart`, `lib/l10n/generated/`,
+  `lib/firebase_options.dart`) are skipped.
+- **`arb_parity_test.dart`** — every locale ARB under `lib/l10n/`
+  defines the same set of translation keys (metadata `@…` keys are
+  ignored). Drift fails CI with the missing keys per file.
+- **`repository_pairing_test.dart`** — every abstract repository in
+  `lib/features/*/data/` has a `Fake*` sibling in the same directory,
+  so the test surface stays honest.
+
+To add a new architectural rule, drop a file under `test/architecture/`
+that walks `lib/` (or another scope), asserts the invariant, and emits
+a `reason:` message that names the offending files. Keep each rule in
+its own test file — a single mega-test that breaks on every kind of
+violation is harder to triage.
+
 ## Public API surface snapshot
 
 `test/api_surface_test.dart` walks every `.dart` file under `lib/`, extracts

--- a/lib/features/picking_lists/domain/quantity_unit.dart
+++ b/lib/features/picking_lists/domain/quantity_unit.dart
@@ -1,6 +1,3 @@
-import 'package:flutter/widgets.dart';
-import 'package:pickllist/l10n/generated/app_localizations.dart';
-
 enum QuantityUnit {
   units,
   kg,
@@ -10,16 +7,4 @@ enum QuantityUnit {
     (u) => u.name == name,
     orElse: () => QuantityUnit.units,
   );
-
-  String localized(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    switch (this) {
-      case QuantityUnit.units:
-        return l.unitUnits;
-      case QuantityUnit.kg:
-        return l.unitKg;
-      case QuantityUnit.boxes:
-        return l.unitBoxes;
-    }
-  }
 }

--- a/lib/features/picking_lists/presentation/widgets/picking_item_tile.dart
+++ b/lib/features/picking_lists/presentation/widgets/picking_item_tile.dart
@@ -5,6 +5,7 @@ import 'package:pickllist/features/auth/application/auth_providers.dart';
 import 'package:pickllist/features/auth/domain/app_user.dart';
 import 'package:pickllist/features/picking_lists/application/picking_list_providers.dart';
 import 'package:pickllist/features/picking_lists/domain/picking_item.dart';
+import 'package:pickllist/features/picking_lists/presentation/widgets/quantity_unit_l10n.dart';
 import 'package:pickllist/features/users/application/user_directory_providers.dart';
 import 'package:pickllist/l10n/generated/app_localizations.dart';
 

--- a/lib/features/picking_lists/presentation/widgets/quantity_unit_l10n.dart
+++ b/lib/features/picking_lists/presentation/widgets/quantity_unit_l10n.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+import 'package:pickllist/features/picking_lists/domain/quantity_unit.dart';
+import 'package:pickllist/l10n/generated/app_localizations.dart';
+
+extension QuantityUnitL10n on QuantityUnit {
+  String localized(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    switch (this) {
+      case QuantityUnit.units:
+        return l.unitUnits;
+      case QuantityUnit.kg:
+        return l.unitKg;
+      case QuantityUnit.boxes:
+        return l.unitBoxes;
+    }
+  }
+}

--- a/test/api_surface.snapshot.txt
+++ b/test/api_surface.snapshot.txt
@@ -18,5 +18,6 @@ lib/features/picking_lists/domain/quantity_unit.dart::enum QuantityUnit
 lib/features/picking_lists/presentation/picking_list_detail_screen.dart::class PickingListDetailScreen
 lib/features/picking_lists/presentation/picking_lists_screen.dart::class PickingListsScreen
 lib/features/picking_lists/presentation/widgets/picking_item_tile.dart::class PickingItemTile
+lib/features/picking_lists/presentation/widgets/quantity_unit_l10n.dart::extension QuantityUnitL10n
 lib/features/users/data/fake_user_directory_repository.dart::class FakeUserDirectoryRepository
 lib/features/users/data/user_directory_repository.dart::abstract class UserDirectoryRepository

--- a/test/architecture/arb_parity_test.dart
+++ b/test/architecture/arb_parity_test.dart
@@ -1,0 +1,52 @@
+// Architectural fitness test (GUARD-03): ARB translation parity.
+//
+// All locale ARB files under `lib/l10n/` must define the same set of
+// translation keys. Metadata keys (those starting with `@`) are excluded
+// from the parity check but still parsed.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('every ARB locale defines the same translation keys', () {
+    final arbDir = Directory('lib/l10n');
+    final files =
+        arbDir
+            .listSync()
+            .whereType<File>()
+            .where((f) => f.path.endsWith('.arb'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+    expect(files, isNotEmpty, reason: 'no ARB files found under lib/l10n');
+
+    final perFile = <String, Set<String>>{};
+    for (final f in files) {
+      final raw = jsonDecode(f.readAsStringSync()) as Map<String, dynamic>;
+      perFile[f.path.replaceAll('\\', '/')] = raw.keys
+          .where((k) => !k.startsWith('@'))
+          .toSet();
+    }
+
+    final union = perFile.values.fold<Set<String>>(
+      <String>{},
+      (acc, keys) => acc..addAll(keys),
+    );
+
+    final missingPerFile = <String, Set<String>>{};
+    perFile.forEach((path, keys) {
+      final missing = union.difference(keys);
+      if (missing.isNotEmpty) missingPerFile[path] = missing;
+    });
+
+    expect(
+      missingPerFile,
+      isEmpty,
+      reason:
+          'ARB files have drifted out of parity. Add the missing keys '
+          '(or remove them everywhere):\n'
+          '${missingPerFile.entries.map((e) => '  ${e.key}: missing ${e.value.toList()..sort()}').join('\n')}',
+    );
+  });
+}

--- a/test/architecture/file_size_test.dart
+++ b/test/architecture/file_size_test.dart
@@ -1,0 +1,74 @@
+// Architectural fitness test (GUARD-03): 400-line file ceiling.
+//
+// Counts non-blank, non-comment lines under `lib/` and fails when any
+// hand-written file exceeds 400. Generated files (l10n, freezed, etc.)
+// are excluded — they regenerate deterministically.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _maxLines = 400;
+
+void main() {
+  test('no hand-written lib file exceeds $_maxLines significant lines', () {
+    final offenders = <String, int>{};
+    for (final file in _dartFilesUnder(Directory('lib'))) {
+      if (_isGenerated(file.path)) continue;
+      final count = _countSignificantLines(file.readAsStringSync());
+      if (count > _maxLines) {
+        offenders[file.path.replaceAll('\\', '/')] = count;
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'Files exceed the $_maxLines-line ceiling. Decompose into focused '
+          'units (extract widgets, split repos by aggregate, etc.):\n'
+          '${offenders.entries.map((e) => '  ${e.key}: ${e.value} lines').join('\n')}',
+    );
+  });
+}
+
+bool _isGenerated(String path) {
+  final normalised = path.replaceAll('\\', '/');
+  if (normalised.endsWith('.g.dart')) return true;
+  if (normalised.endsWith('.freezed.dart')) return true;
+  if (normalised.endsWith('.gr.dart')) return true;
+  if (normalised.contains('/l10n/generated/')) return true;
+  if (normalised.endsWith('firebase_options.dart')) return true;
+  return false;
+}
+
+int _countSignificantLines(String source) {
+  var inBlockComment = false;
+  var count = 0;
+  for (final raw in source.split('\n')) {
+    final line = raw.trim();
+    if (line.isEmpty) continue;
+    if (inBlockComment) {
+      final end = line.indexOf('*/');
+      if (end >= 0) {
+        inBlockComment = false;
+        final after = line.substring(end + 2).trim();
+        if (after.isNotEmpty && !after.startsWith('//')) count++;
+      }
+      continue;
+    }
+    if (line.startsWith('//')) continue;
+    if (line.startsWith('/*')) {
+      if (!line.contains('*/')) inBlockComment = true;
+      continue;
+    }
+    count++;
+  }
+  return count;
+}
+
+Iterable<File> _dartFilesUnder(Directory root) sync* {
+  if (!root.existsSync()) return;
+  for (final entity in root.listSync(recursive: true)) {
+    if (entity is File && entity.path.endsWith('.dart')) yield entity;
+  }
+}

--- a/test/architecture/layer_boundaries_test.dart
+++ b/test/architecture/layer_boundaries_test.dart
@@ -1,0 +1,130 @@
+// Architectural fitness tests (GUARD-03): import-rule invariants.
+//
+// These tests parse `lib/` source files and assert the layering rules
+// documented in `docs/guardrails.md`:
+//
+// - `lib/features/*/domain/` files import only other domain files,
+//   `package:collection`, or `dart:*` — never Flutter/Firebase/Riverpod.
+// - `lib/features/*/data/` files do not import `presentation/`.
+// - `lib/features/*/presentation/` files do not reach into another
+//   feature's `data/` directly. Cross-feature collaboration goes
+//   through `application/`.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final featuresDir = Directory('lib/features');
+
+  test('domain imports stay inside the domain allowlist', () {
+    final violations = <String>[];
+    for (final file in _dartFilesIn(featuresDir, layer: 'domain')) {
+      for (final import in _packageImports(file)) {
+        if (_isAllowedDomainImport(import)) continue;
+        violations.add('${_rel(file)}: $import');
+      }
+    }
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'domain files may only import other domain files, package:collection, '
+          'or dart:* — move framework dependencies up to presentation/data:\n'
+          '${violations.join('\n')}',
+    );
+  });
+
+  test('data files do not import presentation', () {
+    final violations = <String>[];
+    for (final file in _dartFilesIn(featuresDir, layer: 'data')) {
+      for (final import in _packageImports(file)) {
+        if (import.startsWith('package:pickllist/features/') &&
+            import.contains('/presentation/')) {
+          violations.add('${_rel(file)}: $import');
+        }
+      }
+    }
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'data files must not depend on presentation:\n'
+          '${violations.join('\n')}',
+    );
+  });
+
+  test('presentation files do not reach into another feature\'s data', () {
+    final violations = <String>[];
+    for (final file in _dartFilesIn(featuresDir, layer: 'presentation')) {
+      final ownFeature = _featureOf(file);
+      for (final import in _packageImports(file)) {
+        if (!import.startsWith('package:pickllist/features/')) continue;
+        if (!import.contains('/data/')) continue;
+        final targetFeature = _featureFromImport(import);
+        if (targetFeature == ownFeature) continue;
+        violations.add('${_rel(file)}: $import');
+      }
+    }
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'presentation files must collaborate with other features via '
+          'application/, not data/:\n'
+          '${violations.join('\n')}',
+    );
+  });
+}
+
+bool _isAllowedDomainImport(String import) {
+  if (import.startsWith('dart:')) return true;
+  if (import == 'package:collection/collection.dart' ||
+      import.startsWith('package:collection/')) {
+    return true;
+  }
+  if (import.startsWith('package:pickllist/features/') &&
+      import.contains('/domain/')) {
+    return true;
+  }
+  // Relative imports inside a domain/ folder are sibling-only by Dart's
+  // resolution rules — `import 'quantity_unit.dart';` cannot escape the
+  // current directory, so it stays within domain.
+  if (!import.startsWith('package:') && !import.contains('/')) return true;
+  return false;
+}
+
+String? _featureOf(File file) {
+  final segments = file.path.replaceAll('\\', '/').split('/');
+  final idx = segments.indexOf('features');
+  if (idx < 0 || idx + 1 >= segments.length) return null;
+  return segments[idx + 1];
+}
+
+String? _featureFromImport(String import) {
+  final prefix = 'package:pickllist/features/';
+  if (!import.startsWith(prefix)) return null;
+  final rest = import.substring(prefix.length);
+  final slash = rest.indexOf('/');
+  if (slash < 0) return null;
+  return rest.substring(0, slash);
+}
+
+Iterable<File> _dartFilesIn(Directory root, {required String layer}) sync* {
+  if (!root.existsSync()) return;
+  for (final entity in root.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.dart')) continue;
+    final normalised = entity.path.replaceAll('\\', '/');
+    if (normalised.contains('/$layer/')) yield entity;
+  }
+}
+
+Iterable<String> _packageImports(File file) sync* {
+  final pattern = RegExp('^import\\s+[\'"]([^\'"]+)[\'"]', multiLine: true);
+  for (final m in pattern.allMatches(file.readAsStringSync())) {
+    yield m.group(1)!;
+  }
+}
+
+String _rel(File file) => file.path.replaceAll('\\', '/');

--- a/test/architecture/repository_pairing_test.dart
+++ b/test/architecture/repository_pairing_test.dart
@@ -1,0 +1,80 @@
+// Architectural fitness test (GUARD-03): abstract/fake repository pairing.
+//
+// Every abstract repository under `lib/features/*/data/` must have at
+// least one concrete `Fake*` implementation in the same directory. This
+// keeps the test surface honest: when someone adds a new abstract repo,
+// they cannot forget the in-memory fake that the rest of the suite
+// relies on.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('every abstract repository has a Fake* sibling', () {
+    final orphans = <String>[];
+    for (final dataDir in _dataDirs()) {
+      final files = dataDir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.dart'))
+          .toList();
+      final declarations = <String, File>{};
+      for (final file in files) {
+        for (final name in _classDeclarations(file.readAsStringSync())) {
+          declarations[name] = file;
+        }
+      }
+      for (final entry in declarations.entries) {
+        final name = entry.key;
+        if (!_isAbstract(entry.value.readAsStringSync(), name)) continue;
+        if (!name.endsWith('Repository')) continue;
+        final fakeName = 'Fake$name';
+        if (!declarations.containsKey(fakeName)) {
+          orphans.add(
+            '${entry.value.path.replaceAll('\\', '/')}: '
+            '$name has no $fakeName sibling in the same directory',
+          );
+        }
+      }
+    }
+    expect(
+      orphans,
+      isEmpty,
+      reason:
+          'Add an in-memory Fake* implementation alongside each abstract '
+          'repository so tests have something to wire up:\n'
+          '${orphans.join('\n')}',
+    );
+  });
+}
+
+Iterable<Directory> _dataDirs() sync* {
+  final root = Directory('lib/features');
+  if (!root.existsSync()) return;
+  for (final feature in root.listSync().whereType<Directory>()) {
+    final data = Directory('${feature.path}/data');
+    if (data.existsSync()) yield data;
+  }
+}
+
+Iterable<String> _classDeclarations(String source) sync* {
+  final pattern = RegExp(
+    r'^(?:abstract\s+|sealed\s+|base\s+|interface\s+|final\s+|mixin\s+)*'
+    r'class\s+([A-Z][A-Za-z0-9_]*)',
+    multiLine: true,
+  );
+  for (final m in pattern.allMatches(source)) {
+    yield m.group(1)!;
+  }
+}
+
+bool _isAbstract(String source, String className) {
+  final pattern = RegExp(
+    r'^abstract\s+(?:class|interface\s+class|base\s+class|sealed\s+class)\s+'
+    '$className'
+    r'\b',
+    multiLine: true,
+  );
+  return pattern.hasMatch(source);
+}

--- a/test/features/picking_lists/domain/quantity_unit_test.dart
+++ b/test/features/picking_lists/domain/quantity_unit_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickllist/features/picking_lists/domain/quantity_unit.dart';
+
+void main() {
+  group('QuantityUnit.fromName', () {
+    test('resolves a known enum name', () {
+      expect(QuantityUnit.fromName('kg'), QuantityUnit.kg);
+      expect(QuantityUnit.fromName('boxes'), QuantityUnit.boxes);
+      expect(QuantityUnit.fromName('units'), QuantityUnit.units);
+    });
+
+    test('falls back to units for an unknown name', () {
+      expect(QuantityUnit.fromName('unknown-unit'), QuantityUnit.units);
+      expect(QuantityUnit.fromName(''), QuantityUnit.units);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds four parsing-based tests under `test/architecture/` that lock in layering invariants before they erode:

- **`layer_boundaries_test.dart`** — domain may import only domain, `package:collection`, or `dart:*`; data must not depend on presentation; presentation may not reach into another feature's `data/` directly (cross-feature collaboration goes through `application/`).
- **`file_size_test.dart`** — no hand-written file under `lib/` exceeds 400 significant lines (blank lines and comments excluded; generated files skipped).
- **`arb_parity_test.dart`** — every locale ARB under `lib/l10n/` defines the same translation keys.
- **`repository_pairing_test.dart`** — every abstract repository in `lib/features/*/data/` has a `Fake*` sibling in the same directory.

Closes #3.

## Notable refactor (required for the boundary rule to pass on existing code)
`QuantityUnit.localized(BuildContext)` moved out of the domain enum into a new `QuantityUnitL10n` extension at `lib/features/picking_lists/presentation/widgets/quantity_unit_l10n.dart`. The domain enum now has zero Flutter/l10n imports — call sites import the extension where they already live in presentation. Behaviour is identical.

## Why parser-based tests instead of `analyzer`
The roadmap entry suggested the `analyzer` package. Existing guardrail tooling (`check_coverage.dart`, `check_assertion_quality.dart`, `generate_api_snapshot.dart`) all use lightweight regex parsing — same approach here keeps the test suite quick (under 1s for all four files) and avoids pulling a heavy dependency into `dev_dependencies`.

## Self CR
- `dart format --set-exit-if-changed .` — clean.
- `flutter analyze --fatal-infos` — no issues.
- `flutter test --coverage` — 74 tests pass (6 new).
- `dart run tool/check_assertion_quality.dart` — both picking_lists test files under 30%.
- `dart run tool/check_coverage.dart` — 40.30% (above 40.16% baseline).
- `test/api_surface.snapshot.txt` updated for the new `QuantityUnitL10n` extension.

## Test plan
- [x] `flutter analyze --fatal-infos`
- [x] `flutter test --coverage`
- [x] `dart run tool/check_assertion_quality.dart`
- [x] `dart run tool/check_coverage.dart --base origin/main --head HEAD`
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)