### PR TITLE
feat: FirebaseAuthRepository + bootstrap gating (FIRE-03)

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -40,6 +40,7 @@ this file in the same PR.
 | `mocktail` | Lightweight mocking/stubbing in tests. |
 | `fake_cloud_firestore` | Firestore-backed tests without a live backend. |
 | `firebase_auth_mocks` | Firebase Auth test doubles for repository tests. |
+| `mock_exceptions` | Drives `whenCalling(...).thenThrow(...)` against firebase_auth_mocks so tests can exercise FirebaseAuthException → AuthException mapping. |
 
 ## Firebase Functions workspace
 

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -1,20 +1,64 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pickllist/app.dart';
 import 'package:pickllist/core/logging/logger.dart';
+import 'package:pickllist/features/auth/application/auth_providers.dart';
+import 'package:pickllist/features/auth/data/firebase_auth_repository.dart';
+import 'package:pickllist/firebase_options.dart';
 
-/// Async startup: logging, (future) Firebase.initializeApp, then runApp.
+/// Async startup: logging, conditional Firebase.initializeApp, then runApp.
 ///
-/// Once `flutterfire configure` runs, import the generated
-/// `firebase_options.dart` and call `Firebase.initializeApp(options:
-/// DefaultFirebaseOptions.currentPlatform)` here, then override the
-/// fake repository providers in [overrides] below.
+/// When `firebase_options.dart` contains real values (i.e. `flutterfire
+/// configure` has run), Firebase is initialized and the auth repository
+/// is overridden with [FirebaseAuthRepository]. Otherwise the in-memory
+/// fake from [authRepositoryProvider] is used so the POC still runs.
 Future<void> bootstrap({List<Override> overrides = const []}) async {
   WidgetsFlutterBinding.ensureInitialized();
   configureLogging();
   appLogger('bootstrap').info('Starting Pickllist POC');
 
-  runApp(ProviderScope(overrides: overrides, child: const PickllistApp()));
+  final allOverrides = <Override>[...overrides];
+  if (hasRealFirebaseConfig(DefaultFirebaseOptions.currentPlatform)) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    allOverrides.add(
+      authRepositoryProvider.overrideWith(
+        (ref) => FirebaseAuthRepository(
+          auth: fb.FirebaseAuth.instance,
+          firestore: FirebaseFirestore.instance,
+        ),
+      ),
+    );
+  } else {
+    appLogger('bootstrap').info(
+      'Firebase options are placeholders; using fake auth.',
+    );
+  }
+
+  runApp(
+    ProviderScope(overrides: allOverrides, child: const PickllistApp()),
+  );
+}
+
+/// Returns true when [options] looks like a real flutterfire-generated
+/// config rather than the placeholder values left behind when the CLI
+/// hasn't been run for this platform.
+bool hasRealFirebaseConfig(FirebaseOptions options) {
+  bool isPlaceholder(String? v) {
+    if (v == null || v.isEmpty) return true;
+    final upper = v.toUpperCase();
+    return upper.contains('YOUR-') ||
+        upper.contains('PLACEHOLDER') ||
+        upper.contains('XXXX');
+  }
+
+  return !isPlaceholder(options.apiKey) &&
+      !isPlaceholder(options.appId) &&
+      !isPlaceholder(options.projectId);
 }

--- a/lib/features/auth/data/firebase_auth_repository.dart
+++ b/lib/features/auth/data/firebase_auth_repository.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:pickllist/features/auth/data/auth_repository.dart';
+import 'package:pickllist/features/auth/domain/app_user.dart';
+
+/// Maps a [fb.User] together with its `users/{uid}` profile doc into an
+/// [AppUser]. Returning `null` lets callers distinguish "signed out" from
+/// "signed in but missing profile" — the latter throws
+/// [AuthException] from [FirebaseAuthRepository.signIn] but yields
+/// `null` from the auth-state stream so the UI shows the login screen.
+typedef AppUserBuilder =
+    Future<AppUser?> Function(
+      fb.User user,
+      DocumentSnapshot<Map<String, dynamic>> profile,
+    );
+
+/// Firebase-backed [AuthRepository]. Maps `firebase_auth` users into
+/// [AppUser] by reading the `users/{uid}` Firestore document for the
+/// role and display name.
+class FirebaseAuthRepository implements AuthRepository {
+  /// Wires the repository to the live Firebase services.
+  FirebaseAuthRepository({
+    required fb.FirebaseAuth auth,
+    required FirebaseFirestore firestore,
+    AppUserBuilder? builder,
+  }) : _auth = auth,
+       _firestore = firestore,
+       _builder = builder ?? _defaultBuilder;
+
+  final fb.FirebaseAuth _auth;
+  final FirebaseFirestore _firestore;
+  final AppUserBuilder _builder;
+
+  AppUser? _currentUser;
+
+  @override
+  AppUser? get currentUser => _currentUser;
+
+  @override
+  Stream<AppUser?> authStateChanges() {
+    return _auth.authStateChanges().asyncMap((user) async {
+      if (user == null) {
+        _currentUser = null;
+        return null;
+      }
+      final profile = await _profileDoc(user.uid).get();
+      final mapped = await _builder(user, profile);
+      _currentUser = mapped;
+      return mapped;
+    });
+  }
+
+  @override
+  Future<AppUser> signIn({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final cred = await _auth.signInWithEmailAndPassword(
+        email: email.trim(),
+        password: password,
+      );
+      final user = cred.user;
+      if (user == null) {
+        throw const AuthException('unknown-error');
+      }
+      final profile = await _profileDoc(user.uid).get();
+      final mapped = await _builder(user, profile);
+      if (mapped == null) {
+        throw const AuthException('missing-profile');
+      }
+      _currentUser = mapped;
+      return mapped;
+    } on fb.FirebaseAuthException catch (e) {
+      throw AuthException(_mapCode(e.code));
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    await _auth.signOut();
+    _currentUser = null;
+  }
+
+  DocumentReference<Map<String, dynamic>> _profileDoc(String uid) =>
+      _firestore.collection('users').doc(uid);
+
+  static String _mapCode(String code) {
+    switch (code) {
+      case 'invalid-credential':
+      case 'invalid-email':
+      case 'user-not-found':
+      case 'wrong-password':
+        return 'invalid-credentials';
+      case 'user-disabled':
+        return 'user-disabled';
+      case 'too-many-requests':
+        return 'too-many-requests';
+      case 'network-request-failed':
+        return 'network-error';
+      default:
+        return 'unknown-error';
+    }
+  }
+
+  static Future<AppUser?> _defaultBuilder(
+    fb.User user,
+    DocumentSnapshot<Map<String, dynamic>> profile,
+  ) async {
+    final data = profile.data();
+    if (!profile.exists || data == null) return null;
+    final roleName = data['role'] as String? ?? UserRole.worker.name;
+    final displayName =
+        (data['displayName'] as String?) ??
+        user.displayName ??
+        user.email ??
+        user.uid;
+    final email = (data['email'] as String?) ?? user.email ?? '';
+    return AppUser(
+      id: user.uid,
+      email: email,
+      displayName: displayName,
+      role: UserRole.fromName(roleName),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -653,7 +653,7 @@ packages:
     source: hosted
     version: "2.0.0"
   mock_exceptions:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: mock_exceptions
       sha256: "6e3e623712d2c6106ffe9e14732912522b565ddaa82a8dcee6cd4441b5984056"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   json_serializable: ^6.8.0
+  mock_exceptions: ^0.8.2
   mocktail: ^1.0.4
   riverpod_generator: ^2.6.3
   riverpod_lint: ^2.6.3

--- a/test/api_surface.snapshot.txt
+++ b/test/api_surface.snapshot.txt
@@ -4,6 +4,8 @@ lib/core/theme/app_theme.dart::class AppTheme
 lib/features/auth/data/auth_repository.dart::abstract class AuthRepository
 lib/features/auth/data/auth_repository.dart::class AuthException
 lib/features/auth/data/fake_auth_repository.dart::class FakeAuthRepository
+lib/features/auth/data/firebase_auth_repository.dart::class FirebaseAuthRepository
+lib/features/auth/data/firebase_auth_repository.dart::typedef AppUserBuilder
 lib/features/auth/domain/app_user.dart::class AppUser
 lib/features/auth/domain/app_user.dart::enum UserRole
 lib/features/auth/domain/app_user.dart::extension AppUserListX

--- a/test/bootstrap_test.dart
+++ b/test/bootstrap_test.dart
@@ -1,0 +1,47 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickllist/bootstrap.dart';
+
+void main() {
+  group('hasRealFirebaseConfig', () {
+    test('returns true for fully populated options', () {
+      const options = FirebaseOptions(
+        apiKey: 'AIzaSyDVqVZhA4j6DpdNyZ2TQYDN-8axPeF3JzU',
+        appId: '1:36769619694:android:55638dde3b88e75f611dff',
+        messagingSenderId: '36769619694',
+        projectId: 'picklist-by',
+      );
+      expect(hasRealFirebaseConfig(options), isTrue);
+    });
+
+    test('returns false when apiKey is a YOUR-* placeholder', () {
+      const options = FirebaseOptions(
+        apiKey: 'YOUR-API-KEY',
+        appId: '1:0:android:abc',
+        messagingSenderId: '0',
+        projectId: 'demo',
+      );
+      expect(hasRealFirebaseConfig(options), isFalse);
+    });
+
+    test('returns false when appId is empty', () {
+      const options = FirebaseOptions(
+        apiKey: 'AIzaSomething',
+        appId: '',
+        messagingSenderId: '0',
+        projectId: 'demo',
+      );
+      expect(hasRealFirebaseConfig(options), isFalse);
+    });
+
+    test('returns false when projectId looks like a placeholder', () {
+      const options = FirebaseOptions(
+        apiKey: 'AIzaSomething',
+        appId: '1:0:android:abc',
+        messagingSenderId: '0',
+        projectId: 'PLACEHOLDER',
+      );
+      expect(hasRealFirebaseConfig(options), isFalse);
+    });
+  });
+}

--- a/test/features/auth/firebase_auth_repository_test.dart
+++ b/test/features/auth/firebase_auth_repository_test.dart
@@ -1,0 +1,231 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
+import 'package:pickllist/features/auth/data/auth_repository.dart';
+import 'package:pickllist/features/auth/data/firebase_auth_repository.dart';
+import 'package:pickllist/features/auth/domain/app_user.dart';
+
+void main() {
+  group('FirebaseAuthRepository.signIn', () {
+    test('returns AppUser populated from users/{uid} doc', () async {
+      final user = MockUser(
+        uid: 'u_manager',
+        email: 'manager@farm.test',
+        displayName: 'Maya Mock',
+      );
+      final auth = MockFirebaseAuth(mockUser: user);
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('u_manager').set({
+        'email': 'manager@farm.test',
+        'displayName': 'Maya Manager',
+        'role': 'manager',
+      });
+
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+      final result = await repo.signIn(
+        email: 'manager@farm.test',
+        password: 'password123',
+      );
+
+      expect(result.id, 'u_manager');
+      expect(result.role, UserRole.manager);
+      expect(result.displayName, 'Maya Manager');
+      expect(repo.currentUser, result);
+    });
+
+    test('falls back to worker role when profile role is unknown', () async {
+      final user = MockUser(uid: 'u_x', email: 'x@farm.test');
+      final auth = MockFirebaseAuth(mockUser: user);
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('u_x').set({
+        'email': 'x@farm.test',
+        'displayName': 'X',
+        'role': 'unknown_role',
+      });
+
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+      final result = await repo.signIn(email: 'x@farm.test', password: 'pw');
+
+      expect(result.role, UserRole.worker);
+    });
+
+    test('throws missing-profile when users/{uid} doc is absent', () async {
+      final user = MockUser(uid: 'u_orphan', email: 'orphan@farm.test');
+      final auth = MockFirebaseAuth(mockUser: user);
+      final firestore = FakeFirebaseFirestore();
+
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+      expect(
+        () => repo.signIn(email: 'orphan@farm.test', password: 'pw'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'missing-profile',
+          ),
+        ),
+      );
+    });
+
+    test('maps invalid-credential FirebaseAuthException', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(auth)
+          .thenThrow(fb.FirebaseAuthException(code: 'invalid-credential'));
+      final firestore = FakeFirebaseFirestore();
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+      expect(
+        () => repo.signIn(email: 'bad@farm.test', password: 'wrong'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'invalid-credentials',
+          ),
+        ),
+      );
+    });
+
+    test('maps user-disabled FirebaseAuthException', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(
+        Invocation.method(#signInWithEmailAndPassword, null),
+      ).on(auth).thenThrow(fb.FirebaseAuthException(code: 'user-disabled'));
+      final repo = FirebaseAuthRepository(
+        auth: auth,
+        firestore: FakeFirebaseFirestore(),
+      );
+
+      expect(
+        () => repo.signIn(email: 'd@farm.test', password: 'pw'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'user-disabled',
+          ),
+        ),
+      );
+    });
+
+    test('maps too-many-requests FirebaseAuthException', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(
+        Invocation.method(#signInWithEmailAndPassword, null),
+      ).on(auth).thenThrow(fb.FirebaseAuthException(code: 'too-many-requests'));
+      final repo = FirebaseAuthRepository(
+        auth: auth,
+        firestore: FakeFirebaseFirestore(),
+      );
+
+      expect(
+        () => repo.signIn(email: 'd@farm.test', password: 'pw'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'too-many-requests',
+          ),
+        ),
+      );
+    });
+
+    test('maps network-request-failed FirebaseAuthException', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(auth)
+          .thenThrow(fb.FirebaseAuthException(code: 'network-request-failed'));
+      final repo = FirebaseAuthRepository(
+        auth: auth,
+        firestore: FakeFirebaseFirestore(),
+      );
+
+      expect(
+        () => repo.signIn(email: 'd@farm.test', password: 'pw'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'network-error',
+          ),
+        ),
+      );
+    });
+
+    test('maps unrecognized codes to unknown-error', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(
+        Invocation.method(#signInWithEmailAndPassword, null),
+      ).on(auth).thenThrow(fb.FirebaseAuthException(code: 'something-weird'));
+      final repo = FirebaseAuthRepository(
+        auth: auth,
+        firestore: FakeFirebaseFirestore(),
+      );
+
+      expect(
+        () => repo.signIn(email: 'd@farm.test', password: 'pw'),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'unknown-error',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('FirebaseAuthRepository.authStateChanges', () {
+    test('emits AppUser when signed in and null after sign-out', () async {
+      final user = MockUser(
+        uid: 'u_worker',
+        email: 'worker@farm.test',
+        displayName: 'W',
+      );
+      final auth = MockFirebaseAuth(mockUser: user);
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('u_worker').set({
+        'email': 'worker@farm.test',
+        'displayName': 'Wendy Worker',
+        'role': 'worker',
+      });
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+      final stream = repo.authStateChanges();
+      final events = <AppUser?>[];
+      final sub = stream.listen(events.add);
+
+      await repo.signIn(
+        email: 'worker@farm.test',
+        password: 'password123',
+      );
+      await Future<void>.delayed(Duration.zero);
+      await repo.signOut();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events.last, isNull);
+      expect(repo.currentUser, isNull);
+      expect(
+        events.whereType<AppUser>().any((u) => u.id == 'u_worker'),
+        isTrue,
+      );
+      await sub.cancel();
+    });
+
+    test('emits null when profile doc is missing', () async {
+      final user = MockUser(uid: 'u_orphan', email: 'orphan@farm.test');
+      final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+      final repo = FirebaseAuthRepository(
+        auth: auth,
+        firestore: FakeFirebaseFirestore(),
+      );
+
+      final first = await repo.authStateChanges().first;
+      expect(first, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implements `FirebaseAuthRepository` against `firebase_auth`, resolving the role/displayName from the `users/{uid}` Firestore document so UI gating stays role-aware.
- Maps `FirebaseAuthException` codes to the stable `AuthException` strings the UI already handles (`invalid-credentials`, `user-disabled`, `too-many-requests`, `network-error`, `unknown-error`, `missing-profile`).
- Adds `hasRealFirebaseConfig()` in `bootstrap.dart` so we initialize Firebase + override `authRepositoryProvider` only when `firebase_options.dart` carries non-placeholder values; otherwise the in-memory fake stays in place for unconfigured forks.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 105 passing (10 new for `FirebaseAuthRepository`, 4 new for `hasRealFirebaseConfig`)
- [x] API surface snapshot regenerated (`FirebaseAuthRepository`, `AppUserBuilder` typedef)
- [ ] Manual QA against the live `picklist-by` project — flagged in the issue's acceptance criteria; not gateable in CI.

## Self CR
- Tests use `firebase_auth_mocks` with `mock_exceptions.whenCalling(...)` to drive code-path mapping — `mock_exceptions` is now declared as an explicit dev dep so the import isn't depending on a transitive arrangement.
- `authStateChanges` resolves the profile per emission. Acceptable for the POC; if reads start dominating, switch to a Firestore listener cache.
- `_defaultBuilder` is exposed via the `AppUserBuilder` typedef so future tests (or a custom mapping) can swap it without subclassing.

Closes #11