### PR TITLE
feat: add Firebase auth repository

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,10 +58,11 @@ the expected update path when apps are added/removed.
 
 ### Remaining wiring (tracked as issues)
 
-1. In `lib/bootstrap.dart`, replace the no-op `bootstrap` with a real
-   `Firebase.initializeApp` call and add provider overrides for
-   `FirebaseAuthRepository`, `FirestorePickingListRepository`, and
-   `FirestoreUserDirectoryRepository` (`FIRE-03`, `FIRE-04`, `FIRE-05`).
+1. `lib/bootstrap.dart` now initializes Firebase and overrides
+   `authRepositoryProvider` with `FirebaseAuthRepository` when supported
+   platforms have configured `FirebaseOptions` (`FIRE-03`). The
+   Firestore-backed picking-list and user-directory overrides are still
+   pending in `FIRE-04` and `FIRE-05`.
 
 2. Deploy the rules and indexes (`FIRE-06`):
 

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -13,6 +13,7 @@ import 'package:pickllist/features/auth/application/auth_providers.dart';
 import 'package:pickllist/features/auth/data/firebase_auth_repository.dart';
 import 'package:pickllist/firebase_options.dart';
 
+/// Initializes app services and starts the widget tree.
 Future<void> bootstrap({List<Override> overrides = const []}) async {
   WidgetsFlutterBinding.ensureInitialized();
   configureLogging();
@@ -37,6 +38,7 @@ Future<void> bootstrap({List<Override> overrides = const []}) async {
 }
 
 @visibleForTesting
+/// Resolves the Firebase options for supported configured platforms, if any.
 FirebaseOptions? configuredFirebaseOptionsForPlatform() {
   if (kIsWeb) {
     return null;
@@ -57,6 +59,7 @@ FirebaseOptions? configuredFirebaseOptionsForPlatform() {
 }
 
 @visibleForTesting
+/// Returns whether [options] look like real generated Firebase config.
 bool hasConfiguredFirebaseOptions(FirebaseOptions options) {
   return options.apiKey.isNotEmpty &&
       options.appId.isNotEmpty &&

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -1,20 +1,67 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb, visibleForTesting;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pickllist/app.dart';
 import 'package:pickllist/core/logging/logger.dart';
+import 'package:pickllist/features/auth/application/auth_providers.dart';
+import 'package:pickllist/features/auth/data/firebase_auth_repository.dart';
+import 'package:pickllist/firebase_options.dart';
 
-/// Async startup: logging, (future) Firebase.initializeApp, then runApp.
-///
-/// Once `flutterfire configure` runs, import the generated
-/// `firebase_options.dart` and call `Firebase.initializeApp(options:
-/// DefaultFirebaseOptions.currentPlatform)` here, then override the
-/// fake repository providers in [overrides] below.
 Future<void> bootstrap({List<Override> overrides = const []}) async {
   WidgetsFlutterBinding.ensureInitialized();
   configureLogging();
   appLogger('bootstrap').info('Starting Pickllist POC');
 
-  runApp(ProviderScope(overrides: overrides, child: const PickllistApp()));
+  final appOverrides = [...overrides];
+  final firebaseOptions = configuredFirebaseOptionsForPlatform();
+
+  if (firebaseOptions != null) {
+    await Firebase.initializeApp(options: firebaseOptions);
+    appOverrides.add(
+      authRepositoryProvider.overrideWithValue(
+        FirebaseAuthRepository(
+          auth: FirebaseAuth.instance,
+          firestore: FirebaseFirestore.instance,
+        ),
+      ),
+    );
+  }
+
+  runApp(ProviderScope(overrides: appOverrides, child: const PickllistApp()));
+}
+
+@visibleForTesting
+FirebaseOptions? configuredFirebaseOptionsForPlatform() {
+  if (kIsWeb) {
+    return null;
+  }
+
+  final options = switch (defaultTargetPlatform) {
+    TargetPlatform.android => DefaultFirebaseOptions.android,
+    TargetPlatform.iOS => DefaultFirebaseOptions.ios,
+    TargetPlatform.windows => DefaultFirebaseOptions.windows,
+    _ => null,
+  };
+
+  if (options == null) {
+    return null;
+  }
+
+  return hasConfiguredFirebaseOptions(options) ? options : null;
+}
+
+@visibleForTesting
+bool hasConfiguredFirebaseOptions(FirebaseOptions options) {
+  return options.apiKey.isNotEmpty &&
+      options.appId.isNotEmpty &&
+      options.projectId.isNotEmpty &&
+      !options.apiKey.startsWith('YOUR_') &&
+      !options.appId.startsWith('YOUR_') &&
+      !options.projectId.startsWith('YOUR_');
 }

--- a/lib/features/auth/application/auth_providers.dart
+++ b/lib/features/auth/application/auth_providers.dart
@@ -4,7 +4,7 @@ import 'package:pickllist/features/auth/data/fake_auth_repository.dart';
 import 'package:pickllist/features/auth/domain/app_user.dart';
 
 /// The single auth repository. In the POC this is the fake impl; the
-/// Firebase impl will override this provider in `main.dart` once
+/// Firebase impl will override this provider in `bootstrap.dart` once
 /// `firebase_options.dart` is generated.
 final authRepositoryProvider = Provider<AuthRepository>((ref) {
   return FakeAuthRepository();

--- a/lib/features/auth/data/firebase_auth_repository.dart
+++ b/lib/features/auth/data/firebase_auth_repository.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:logging/logging.dart';
+import 'package:pickllist/core/logging/logger.dart';
+import 'package:pickllist/features/auth/data/auth_repository.dart';
+import 'package:pickllist/features/auth/domain/app_user.dart';
+
+/// Firebase-backed implementation of [AuthRepository].
+class FirebaseAuthRepository implements AuthRepository {
+  /// Creates a Firebase-backed auth repository.
+  FirebaseAuthRepository({
+    required FirebaseAuth auth,
+    required FirebaseFirestore firestore,
+  }) : _auth = auth,
+       _firestore = firestore;
+
+  final FirebaseAuth _auth;
+  final FirebaseFirestore _firestore;
+  final Logger _logger = appLogger('FirebaseAuthRepository');
+
+  AppUser? _currentUser;
+
+  @override
+  AppUser? get currentUser => _currentUser;
+
+  @override
+  Stream<AppUser?> authStateChanges() {
+    return _auth.authStateChanges().asyncMap((firebaseUser) async {
+      if (firebaseUser == null) {
+        _currentUser = null;
+        return null;
+      }
+
+      final appUser = await _loadAppUser(firebaseUser);
+      if (appUser == null) {
+        _currentUser = null;
+        unawaited(_auth.signOut());
+        return null;
+      }
+
+      _currentUser = appUser;
+      return appUser;
+    });
+  }
+
+  @override
+  Future<AppUser> signIn({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final credential = await _auth.signInWithEmailAndPassword(
+        email: email.trim(),
+        password: password,
+      );
+      final firebaseUser = credential.user;
+      if (firebaseUser == null) {
+        throw const AuthException('user-not-found');
+      }
+
+      final appUser = await _loadAppUser(firebaseUser);
+      if (appUser == null) {
+        await _auth.signOut();
+        throw const AuthException('missing-user-profile');
+      }
+
+      _currentUser = appUser;
+      return appUser;
+    } on FirebaseAuthException catch (error) {
+      throw AuthException(error.code);
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    _currentUser = null;
+    await _auth.signOut();
+  }
+
+  Future<AppUser?> _loadAppUser(User firebaseUser) async {
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(firebaseUser.uid)
+        .get();
+    final data = snapshot.data();
+
+    if (!snapshot.exists || data == null) {
+      _logger.warning(
+        'Missing users/${firebaseUser.uid} profile for signed-in Firebase user.',
+      );
+      return null;
+    }
+
+    return AppUser(
+      id: snapshot.id,
+      email: ((data['email'] as String?) ?? firebaseUser.email ?? '')
+          .trim()
+          .toLowerCase(),
+      displayName:
+          (data['displayName'] as String?) ??
+          firebaseUser.displayName ??
+          firebaseUser.email ??
+          snapshot.id,
+      role: UserRole.fromName(
+        (data['role'] as String?) ?? UserRole.worker.name,
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -13,8 +13,8 @@ class LoginScreen extends ConsumerStatefulWidget {
 
 class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _formKey = GlobalKey<FormState>();
-  final _emailCtrl = TextEditingController(text: 'manager@farm.test');
-  final _passCtrl = TextEditingController(text: 'password123');
+  final _emailCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
   bool _submitting = false;
   String? _error;
 

--- a/test/api_surface.snapshot.txt
+++ b/test/api_surface.snapshot.txt
@@ -4,6 +4,7 @@ lib/core/theme/app_theme.dart::class AppTheme
 lib/features/auth/data/auth_repository.dart::abstract class AuthRepository
 lib/features/auth/data/auth_repository.dart::class AuthException
 lib/features/auth/data/fake_auth_repository.dart::class FakeAuthRepository
+lib/features/auth/data/firebase_auth_repository.dart::class FirebaseAuthRepository
 lib/features/auth/domain/app_user.dart::class AppUser
 lib/features/auth/domain/app_user.dart::enum UserRole
 lib/features/auth/domain/app_user.dart::extension AppUserListX

--- a/test/app_smoke_test.dart
+++ b/test/app_smoke_test.dart
@@ -16,7 +16,11 @@ void main() {
     await tester.pumpWidget(const ProviderScope(child: PickllistApp()));
     await tester.pumpAndSettle();
 
-    // Defaults already filled in by LoginScreen for the POC.
+    await tester.enterText(
+      find.byType(TextFormField).at(0),
+      'manager@farm.test',
+    );
+    await tester.enterText(find.byType(TextFormField).at(1), 'password123');
     await tester.tap(find.byType(FilledButton));
     await tester.pumpAndSettle();
 

--- a/test/bootstrap_test.dart
+++ b/test/bootstrap_test.dart
@@ -1,0 +1,43 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickllist/bootstrap.dart';
+import 'package:pickllist/firebase_options.dart';
+
+void main() {
+  group('hasConfiguredFirebaseOptions', () {
+    test('accepts the committed Android/iOS/Windows Firebase options', () {
+      expect(
+        hasConfiguredFirebaseOptions(DefaultFirebaseOptions.android),
+        isTrue,
+      );
+      expect(hasConfiguredFirebaseOptions(DefaultFirebaseOptions.ios), isTrue);
+      expect(
+        hasConfiguredFirebaseOptions(DefaultFirebaseOptions.windows),
+        isTrue,
+      );
+    });
+
+    test('rejects placeholder-like Firebase options', () {
+      const placeholder = FirebaseOptions(
+        apiKey: 'YOUR_API_KEY',
+        appId: 'YOUR_APP_ID',
+        messagingSenderId: '1234567890',
+        projectId: 'YOUR_PROJECT_ID',
+      );
+
+      expect(hasConfiguredFirebaseOptions(placeholder), isFalse);
+    });
+  });
+
+  group('configuredFirebaseOptionsForPlatform', () {
+    test(
+      'returns a configured option for the current supported test platform',
+      () {
+        final options = configuredFirebaseOptionsForPlatform();
+
+        expect(options, isNotNull);
+        expect(options?.projectId, 'picklist-by');
+      },
+    );
+  });
+}

--- a/test/features/auth/firebase_auth_repository_test.dart
+++ b/test/features/auth/firebase_auth_repository_test.dart
@@ -1,0 +1,144 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pickllist/features/auth/data/auth_repository.dart';
+import 'package:pickllist/features/auth/data/firebase_auth_repository.dart';
+import 'package:pickllist/features/auth/domain/app_user.dart';
+
+class _MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late MockUser mockUser;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    mockUser = MockUser(
+      uid: 'u_manager',
+      email: 'manager@farm.test',
+      displayName: 'Firebase Maya',
+    );
+  });
+
+  Future<void> seedUserDoc({
+    String uid = 'u_manager',
+    String email = 'manager@farm.test',
+    String displayName = 'Maya Manager',
+    String role = 'manager',
+  }) {
+    return firestore.collection('users').doc(uid).set({
+      'email': email,
+      'displayName': displayName,
+      'role': role,
+    });
+  }
+
+  test(
+    'signIn returns Firestore-backed AppUser and updates currentUser',
+    () async {
+      await seedUserDoc();
+      final auth = MockFirebaseAuth(mockUser: mockUser);
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+      final user = await repo.signIn(
+        email: 'manager@farm.test',
+        password: 'password123',
+      );
+
+      expect(
+        user,
+        const AppUser(
+          id: 'u_manager',
+          email: 'manager@farm.test',
+          displayName: 'Maya Manager',
+          role: UserRole.manager,
+        ),
+      );
+      expect(repo.currentUser, user);
+    },
+  );
+
+  test(
+    'authStateChanges maps Firebase user to AppUser via Firestore',
+    () async {
+      await seedUserDoc(displayName: 'Manager From Firestore');
+      final auth = MockFirebaseAuth(mockUser: mockUser);
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+      final events = <AppUser?>[];
+      final sub = repo.authStateChanges().listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      await auth.signInWithEmailAndPassword(
+        email: 'manager@farm.test',
+        password: 'password123',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        events.last,
+        const AppUser(
+          id: 'u_manager',
+          email: 'manager@farm.test',
+          displayName: 'Manager From Firestore',
+          role: UserRole.manager,
+        ),
+      );
+      await sub.cancel();
+    },
+  );
+
+  test('signIn maps FirebaseAuthException codes to AuthException', () async {
+    final auth = _MockFirebaseAuth();
+    when(
+      () => auth.signInWithEmailAndPassword(
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenThrow(FirebaseAuthException(code: 'wrong-password'));
+    final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+    await expectLater(
+      () => repo.signIn(email: 'manager@farm.test', password: 'bad'),
+      throwsA(
+        isA<AuthException>().having(
+          (error) => error.message,
+          'message',
+          'wrong-password',
+        ),
+      ),
+    );
+  });
+
+  test('signIn throws when the Firestore profile is missing', () async {
+    final auth = MockFirebaseAuth(mockUser: mockUser);
+    final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+    await expectLater(
+      () => repo.signIn(email: 'manager@farm.test', password: 'password123'),
+      throwsA(
+        isA<AuthException>().having(
+          (error) => error.message,
+          'message',
+          'missing-user-profile',
+        ),
+      ),
+    );
+    expect(repo.currentUser, isNull);
+  });
+
+  test('signOut clears currentUser', () async {
+    await seedUserDoc();
+    final auth = MockFirebaseAuth(mockUser: mockUser);
+    final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+
+    await repo.signIn(email: 'manager@farm.test', password: 'password123');
+    expect(repo.currentUser, isNotNull);
+
+    await repo.signOut();
+
+    expect(repo.currentUser, isNull);
+  });
+}


### PR DESCRIPTION
Closes #11

## Summary
- add `FirebaseAuthRepository` to map Firebase Auth users through Firestore `users/{uid}` docs into `AppUser` with role/displayName
- initialize Firebase auth in `bootstrap.dart` on supported configured platforms and cover that gating with bootstrap tests
- remove prefilled demo credentials from the login screen and update smoke tests to enter fake-mode credentials explicitly

## Tests
- `dart format --set-exit-if-changed .`
- `flutter analyze --fatal-infos`
- `flutter gen-l10n`
- `flutter test test/bootstrap_test.dart test/app_smoke_test.dart test/features/auth/firebase_auth_repository_test.dart`
- `flutter test --coverage`
- `dart run tool/check_assertion_quality.dart`
- `dart run tool/check_coverage.dart --base origin/main --head HEAD`
- `dart run tool/check_dependency_docs.dart --base origin/main --head HEAD`
- `dart run tool/generate_api_snapshot.dart --write`

## Blocked before merge
- Issue #11 requires manual QA that sign-in works against the live project.
- `FIRE-08` (seed the first manager account) is still open, and the known fake seed credentials (`manager@farm.test` / `password123`) are **not** accepted by the live Firebase project, so this PR is opened as draft pending real-account verification.

## Docs / dependency notes
- `docs/setup.md` now reflects that auth bootstrap wiring is done in `FIRE-03`, while Firestore-backed repository overrides remain pending in `FIRE-04` / `FIRE-05`.
- No dependency changes were required.

## Self CR
- Reviewed final diff and commit split locally.
- Fixed follow-up blockers from review: stale bootstrap docs/comments, missing bootstrap gating tests, and seeded login defaults in the real-Firebase path.
- Residual blocker is external/manual: live-project sign-in verification still needs a provisioned real manager account.