### PR TITLE
feat: FirestoreUserDirectoryRepository (FIRE-05)

### DIFF
--- a/lib/features/users/application/user_directory_providers.dart
+++ b/lib/features/users/application/user_directory_providers.dart
@@ -2,11 +2,13 @@
 // core/domain/data only.
 // ignore_for_file: public_member_api_docs
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pickllist/features/auth/application/auth_providers.dart';
 import 'package:pickllist/features/auth/data/fake_auth_repository.dart';
 import 'package:pickllist/features/auth/domain/app_user.dart';
 import 'package:pickllist/features/users/data/fake_user_directory_repository.dart';
+import 'package:pickllist/features/users/data/firestore_user_directory_repository.dart';
 import 'package:pickllist/features/users/data/user_directory_repository.dart';
 
 final userDirectoryRepositoryProvider = Provider<UserDirectoryRepository>((
@@ -16,10 +18,7 @@ final userDirectoryRepositoryProvider = Provider<UserDirectoryRepository>((
   if (auth is FakeAuthRepository) {
     return FakeUserDirectoryRepository(auth);
   }
-  throw UnimplementedError(
-    'Firestore-backed UserDirectoryRepository not wired yet. '
-    'See docs/architecture.md.',
-  );
+  return FirestoreUserDirectoryRepository(FirebaseFirestore.instance);
 });
 
 final userDirectoryProvider = StreamProvider<List<AppUser>>((ref) {

--- a/lib/features/users/data/firestore_user_directory_repository.dart
+++ b/lib/features/users/data/firestore_user_directory_repository.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:pickllist/features/auth/domain/app_user.dart';
+import 'package:pickllist/features/users/data/user_directory_repository.dart';
+
+/// Firestore-backed user directory. Streams `users/` ordered by
+/// `displayName` so the assignee picker is alphabetised without
+/// client-side sort cost.
+class FirestoreUserDirectoryRepository implements UserDirectoryRepository {
+  /// Wires the repository to a Firestore instance.
+  FirestoreUserDirectoryRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _users =>
+      _firestore.collection('users');
+
+  @override
+  Stream<List<AppUser>> watchUsers() {
+    return _users
+        .orderBy('displayName')
+        .snapshots()
+        .map(
+          (snap) => snap.docs
+              .map((d) => _toAppUser(d.id, d.data()))
+              .toList(growable: false),
+        );
+  }
+
+  @override
+  Future<AppUser?> userById(String id) async {
+    final doc = await _users.doc(id).get();
+    final data = doc.data();
+    if (!doc.exists || data == null) return null;
+    return _toAppUser(doc.id, data);
+  }
+
+  static AppUser _toAppUser(String id, Map<String, dynamic> data) {
+    return AppUser(
+      id: id,
+      email: (data['email'] as String?) ?? '',
+      displayName: (data['displayName'] as String?) ?? '',
+      role: UserRole.fromName(
+        (data['role'] as String?) ?? UserRole.worker.name,
+      ),
+    );
+  }
+}

--- a/test/api_surface.snapshot.txt
+++ b/test/api_surface.snapshot.txt
@@ -22,4 +22,5 @@ lib/features/picking_lists/presentation/picking_lists_screen.dart::class Picking
 lib/features/picking_lists/presentation/widgets/picking_item_tile.dart::class PickingItemTile
 lib/features/picking_lists/presentation/widgets/quantity_unit_l10n.dart::extension QuantityUnitL10n
 lib/features/users/data/fake_user_directory_repository.dart::class FakeUserDirectoryRepository
+lib/features/users/data/firestore_user_directory_repository.dart::class FirestoreUserDirectoryRepository
 lib/features/users/data/user_directory_repository.dart::abstract class UserDirectoryRepository

--- a/test/features/users/data/firestore_user_directory_repository_test.dart
+++ b/test/features/users/data/firestore_user_directory_repository_test.dart
@@ -1,0 +1,91 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickllist/features/auth/domain/app_user.dart';
+import 'package:pickllist/features/users/data/firestore_user_directory_repository.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late FirestoreUserDirectoryRepository repo;
+
+  setUp(() async {
+    firestore = FakeFirebaseFirestore();
+    repo = FirestoreUserDirectoryRepository(firestore);
+    await firestore.collection('users').doc('u_zoe').set({
+      'email': 'zoe@farm.test',
+      'displayName': 'Zoe Worker',
+      'role': 'worker',
+    });
+    await firestore.collection('users').doc('u_anna').set({
+      'email': 'anna@farm.test',
+      'displayName': 'Anna Manager',
+      'role': 'manager',
+    });
+    await firestore.collection('users').doc('u_milo').set({
+      'email': 'milo@farm.test',
+      'displayName': 'Milo Worker',
+      'role': 'worker',
+    });
+  });
+
+  test('watchUsers streams users sorted by displayName', () async {
+    final users = await repo.watchUsers().first;
+    expect(users.map((u) => u.displayName), [
+      'Anna Manager',
+      'Milo Worker',
+      'Zoe Worker',
+    ]);
+    expect(users.first.role, UserRole.manager);
+  });
+
+  test('watchUsers emits a new event when a user is added', () async {
+    final stream = repo.watchUsers();
+    final emissions = <List<AppUser>>[];
+    final sub = stream.listen(emissions.add);
+    await Future<void>.delayed(Duration.zero);
+
+    await firestore.collection('users').doc('u_bob').set({
+      'email': 'bob@farm.test',
+      'displayName': 'Bob Worker',
+      'role': 'worker',
+    });
+    await Future<void>.delayed(Duration.zero);
+
+    expect(emissions.last.map((u) => u.displayName), [
+      'Anna Manager',
+      'Bob Worker',
+      'Milo Worker',
+      'Zoe Worker',
+    ]);
+    await sub.cancel();
+  });
+
+  test('userById returns the matching AppUser', () async {
+    final user = await repo.userById('u_anna');
+    expect(user, isNotNull);
+    expect(user!.email, 'anna@farm.test');
+    expect(user.role, UserRole.manager);
+  });
+
+  test('userById returns null for unknown ids', () async {
+    expect(await repo.userById('u_missing'), isNull);
+  });
+
+  test('falls back to worker for unknown role strings', () async {
+    await firestore.collection('users').doc('u_weird').set({
+      'email': 'weird@farm.test',
+      'displayName': 'Weird User',
+      'role': 'astronaut',
+    });
+    final user = await repo.userById('u_weird');
+    expect(user!.role, UserRole.worker);
+  });
+
+  test('uses empty strings for missing email and displayName fields', () async {
+    await firestore.collection('users').doc('u_partial').set({
+      'role': 'worker',
+    });
+    final user = await repo.userById('u_partial');
+    expect(user!.email, '');
+    expect(user.displayName, '');
+  });
+}


### PR DESCRIPTION
## Summary
- Implements `FirestoreUserDirectoryRepository` streaming the `users/` collection ordered by `displayName` so the assignee picker is alphabetised without client-side sorting.
- Single-doc `userById` for direct lookups.
- Provider now returns the Firestore impl when the real auth repo is in use; fake remains for the in-memory POC.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 111 passing (6 new for `FirestoreUserDirectoryRepository`)
- [x] API surface snapshot regenerated
- [ ] Manual QA against the live `picklist-by` project — tracked separately under FIRE-08 once a manager account is seeded.

## Self CR
- Tests use `fake_cloud_firestore` end-to-end including the live-snapshot path (add a doc → next emission contains it sorted in).
- `_toAppUser` mirrors the FIRE-03 mapping: missing fields default to empty strings, unknown roles fall back to `worker` so a stray Firestore write can't crash the assignee picker.
- Sort happens server-side via `orderBy('displayName')` so a future Firestore index requirement will surface in the rules tests (FIRE-07) rather than at runtime.

Closes #13