### PR TITLE
feat: gate inactive users in Firestore rules + AppUser.active field (FIRE-07 follow-up)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -15,6 +15,7 @@ provision a worker account. `uid` matches the Firebase Auth UID.
 | `email`       | string                              | lowercased                         |
 | `displayName` | string                              |                                    |
 | `role`        | `"manager"` \| `"worker"`           | drives Firestore rules             |
+| `active`      | bool                                | `true`; set to `false` to revoke access |
 | `fcmTokens`   | array\<string\>                     | device tokens for push (future)    |
 
 ### `crops/{cropId}`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -76,6 +76,23 @@ the expected update path when apps are added/removed.
    Firestore with `role: "manager"`. After that the manager creates
    workers from the Windows app.
 
+4. **Deactivate a user** — set `active: false` on their `users/<uid>` document.
+   Firestore rules gate every read and write on `active != false`, so the
+   account is locked out immediately without deleting the Auth credential.
+   To re-activate, flip the field back to `true`.
+
+   Firestore console (one-off): open `users/<uid>` and set `active` to `false`.
+
+   Firebase CLI (scripted):
+   ```sh
+   firebase firestore:documents:update \
+     "users/<uid>" \
+     --field active --value false --type boolean \
+     --project picklist-by
+   ```
+
+   A manager UI for deactivation is tracked as part of `MGMT-02`.
+
 ## Local Firestore emulator
 
 Useful during development so you don't thrash the real project.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -9,7 +9,8 @@ service cloud.firestore {
     // ---------- helpers ----------
     function isSignedIn()   { return request.auth != null; }
     function myRole()       { return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role; }
-    function isManager()    { return isSignedIn() && myRole() == 'manager'; }
+    function isActive()     { return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.get('active', true) != false; }
+    function isManager()    { return isSignedIn() && isActive() && myRole() == 'manager'; }
     function myUid()        { return request.auth.uid; }
 
     // Fields that a worker is allowed to modify on a picking list item.
@@ -23,13 +24,13 @@ service cloud.firestore {
     // Firebase Admin SDK from a manager tool). Any signed-in user can read
     // the directory (needed for the assignee picker).
     match /users/{uid} {
-      allow read: if isSignedIn();
+      allow read: if isSignedIn() && isActive();
       allow write: if isManager();
     }
 
     // ---------- crops ----------
     match /crops/{cropId} {
-      allow read:  if isSignedIn();
+      allow read:  if isSignedIn() && isActive();
       allow write: if isManager();
     }
 
@@ -38,7 +39,7 @@ service cloud.firestore {
     // draft and completed). See docs/data-model.md.
     match /pickingLists/{listId} {
       allow read:   if isManager()
-                    || (isSignedIn() && resource.data.status != 'draft');
+                    || (isSignedIn() && isActive() && resource.data.status != 'draft');
       allow create: if isManager();
       allow update: if isManager();
       allow delete: if isManager();
@@ -47,7 +48,7 @@ service cloud.firestore {
         // Items inherit the parent list's visibility: a worker can only
         // read item rows if they could read the parent list.
         allow read: if isManager()
-                    || (isSignedIn()
+                    || (isSignedIn() && isActive()
                         && get(/databases/$(database)/documents/pickingLists/$(listId)).data.status != 'draft');
 
         // Manager can do anything.
@@ -55,7 +56,7 @@ service cloud.firestore {
 
         // Workers can claim (set assignedTo to themselves), release their
         // own row (null), and mark their assigned row picked.
-        allow update: if isSignedIn()
+        allow update: if isSignedIn() && isActive()
           && !isManager()
           && workerOnlyTouchesAllowedFields()
           && (
@@ -78,7 +79,7 @@ service cloud.firestore {
 
     // ---------- templates ----------
     match /templates/{templateId} {
-      allow read:  if isSignedIn();
+      allow read:  if isSignedIn() && isActive();
       allow write: if isManager();
     }
   }

--- a/firebase/rules-tests/test/helpers.mjs
+++ b/firebase/rules-tests/test/helpers.mjs
@@ -45,6 +45,8 @@ export async function seedFixture(env) {
     await db.doc('users/manager_1').set({ role: 'manager', email: 'm@x', displayName: 'M' });
     await db.doc('users/worker_a').set({ role: 'worker',  email: 'a@x', displayName: 'A' });
     await db.doc('users/worker_b').set({ role: 'worker',  email: 'b@x', displayName: 'B' });
+    await db.doc('users/inactive_worker').set({ role: 'worker', email: 'i@x', displayName: 'Inactive', active: false });
+    await db.doc('users/inactive_manager').set({ role: 'manager', email: 'im@x', displayName: 'InactiveMgr', active: false });
 
     await db.doc('pickingLists/list_pub').set({
       name: 'Published list',

--- a/firebase/rules-tests/test/picking_lists.test.mjs
+++ b/firebase/rules-tests/test/picking_lists.test.mjs
@@ -26,6 +26,12 @@ function asWorker(uid = 'worker_a') {
 function asUnsigned() {
   return env.unauthenticatedContext().firestore();
 }
+function asInactiveWorker() {
+  return env.authenticatedContext('inactive_worker').firestore();
+}
+function asInactiveManager() {
+  return env.authenticatedContext('inactive_manager').firestore();
+}
 
 test('manager can do anything: read/create/update/delete picking lists', async () => {
   const db = asManager();
@@ -172,4 +178,71 @@ test('manager can write users and crops and templates', async () => {
   await assertSucceeds(db.doc('users/new').set({ role: 'worker', email: 'x', displayName: 'x' }));
   await assertSucceeds(db.doc('crops/c_x').set({ name: 'x', defaultUnit: 'kg', active: true }));
   await assertSucceeds(db.doc('templates/t2').set({ name: 'Saturday', items: [] }));
+});
+
+test('inactive worker cannot read published picking list', async () => {
+  const db = asInactiveWorker();
+  await assertFails(db.doc(PUB_LIST).get());
+});
+
+test('inactive worker cannot read users directory', async () => {
+  const db = asInactiveWorker();
+  await assertFails(db.doc('users/worker_a').get());
+});
+
+test('inactive worker cannot claim a picking list item row', async () => {
+  const db = asInactiveWorker();
+  await assertFails(
+    db.doc(`${PUB_LIST}/items/free`).update({ assignedTo: 'inactive_worker' }),
+  );
+});
+
+test('inactive manager cannot write picking lists', async () => {
+  const db = asInactiveManager();
+  await assertFails(
+    db.collection('pickingLists').doc('mgr_new').set({
+      name: 'New', scheduledAt: new Date(), status: 'draft',
+      createdBy: 'inactive_manager', updatedAt: new Date(),
+    }),
+  );
+});
+
+test('inactive manager cannot write users', async () => {
+  const db = asInactiveManager();
+  await assertFails(db.doc('users/new').set({ role: 'worker', email: 'x', displayName: 'x' }));
+});
+
+test('inactive worker cannot read crops', async () => {
+  const db = asInactiveWorker();
+  await assertFails(db.doc('crops/c_t').get());
+});
+
+test('inactive worker cannot mark a row picked', async () => {
+  // inactive_worker is not the assignee, but even an owned row should be blocked
+  const db = asInactiveWorker();
+  await assertFails(
+    db.doc(`${PUB_LIST}/items/free`).update({
+      assignedTo: 'inactive_worker',
+      pickedQuantity: 5,
+      pickedAt: new Date(),
+      completedBy: 'inactive_worker',
+    }),
+  );
+});
+
+test('inactive worker cannot release a row', async () => {
+  const db = asInactiveWorker();
+  await assertFails(
+    db.doc(`${PUB_LIST}/items/free`).update({ assignedTo: null }),
+  );
+});
+
+test('inactive manager cannot write crops', async () => {
+  const db = asInactiveManager();
+  await assertFails(db.doc('crops/c_new').set({ name: 'Lettuce', defaultUnit: 'kg', active: true }));
+});
+
+test('inactive manager cannot write templates', async () => {
+  const db = asInactiveManager();
+  await assertFails(db.doc('templates/t_new').set({ name: 'Monday', items: [] }));
 });

--- a/lib/features/auth/data/firebase_auth_repository.dart
+++ b/lib/features/auth/data/firebase_auth_repository.dart
@@ -111,6 +111,8 @@ class FirebaseAuthRepository implements AuthRepository {
   ) async {
     final data = profile.data();
     if (!profile.exists || data == null) return null;
+    final active = (data['active'] as bool?) ?? true;
+    if (!active) return null;
     final roleName = data['role'] as String? ?? UserRole.worker.name;
     final displayName =
         (data['displayName'] as String?) ??
@@ -123,6 +125,7 @@ class FirebaseAuthRepository implements AuthRepository {
       email: email,
       displayName: displayName,
       role: UserRole.fromName(roleName),
+      active: active,
     );
   }
 }

--- a/lib/features/auth/domain/app_user.dart
+++ b/lib/features/auth/domain/app_user.dart
@@ -25,6 +25,7 @@ class AppUser {
     required this.email,
     required this.displayName,
     required this.role,
+    this.active = true,
   });
 
   /// Creates a user from a serialized map.
@@ -33,6 +34,7 @@ class AppUser {
     email: map['email'] as String,
     displayName: map['displayName'] as String,
     role: UserRole.fromName(map['role'] as String),
+    active: (map['active'] as bool?) ?? true,
   );
 
   /// Stable user id from the auth/user store.
@@ -47,6 +49,9 @@ class AppUser {
   /// Authorization role for feature gating.
   final UserRole role;
 
+  /// Whether this user has active access. Set to `false` to revoke access.
+  final bool active;
+
   /// Whether this user can access manager-only features.
   bool get isManager => role == UserRole.manager;
 
@@ -56,12 +61,14 @@ class AppUser {
     String? email,
     String? displayName,
     UserRole? role,
+    bool? active,
   }) {
     return AppUser(
       id: id ?? this.id,
       email: email ?? this.email,
       displayName: displayName ?? this.displayName,
       role: role ?? this.role,
+      active: active ?? this.active,
     );
   }
 
@@ -71,6 +78,7 @@ class AppUser {
     'email': email,
     'displayName': displayName,
     'role': role.name,
+    'active': active,
   };
 
   @override
@@ -80,13 +88,15 @@ class AppUser {
           other.id == id &&
           other.email == email &&
           other.displayName == displayName &&
-          other.role == role);
+          other.role == role &&
+          other.active == active);
 
   @override
-  int get hashCode => Object.hash(id, email, displayName, role);
+  int get hashCode => Object.hash(id, email, displayName, role, active);
 
   @override
-  String toString() => 'AppUser(id: $id, email: $email, role: ${role.name})';
+  String toString() =>
+      'AppUser(id: $id, email: $email, role: ${role.name}, active: $active)';
 }
 
 /// Convenience lookups for user collections.

--- a/test/features/auth/domain/app_user_test.dart
+++ b/test/features/auth/domain/app_user_test.dart
@@ -19,8 +19,47 @@ void main() {
 
     expect(roundTrip, manager);
     expect(roundTrip.isManager, isTrue);
+    expect(roundTrip.active, isTrue);
     expect(roundTrip.hashCode, manager.hashCode);
     expect(roundTrip.toString(), contains('manager@farm.test'));
+    expect(roundTrip.toString(), contains('active: true'));
+  });
+
+  test('fromMap defaults active to true when field is absent', () {
+    final map = {
+      'id': 'u_x',
+      'email': 'x@farm.test',
+      'displayName': 'X',
+      'role': 'worker',
+    };
+    final user = AppUser.fromMap(map);
+    expect(user.active, isTrue);
+  });
+
+  test('fromMap respects active: false', () {
+    final map = {
+      'id': 'u_inactive',
+      'email': 'i@farm.test',
+      'displayName': 'Inactive',
+      'role': 'worker',
+      'active': false,
+    };
+    final user = AppUser.fromMap(map);
+    expect(user.active, isFalse);
+  });
+
+  test('toMap includes active field', () {
+    final map = manager.toMap();
+    expect(map['active'], isTrue);
+
+    const inactive = AppUser(
+      id: 'u_i',
+      email: 'i@farm.test',
+      displayName: 'Inactive',
+      role: UserRole.worker,
+      active: false,
+    );
+    expect(inactive.toMap()['active'], isFalse);
   });
 
   test('copyWith replaces selected fields only', () {
@@ -32,6 +71,31 @@ void main() {
     expect(worker.id, manager.id);
     expect(worker.displayName, 'Wendy');
     expect(worker.isManager, isFalse);
+    expect(worker.active, isTrue);
+  });
+
+  test('copyWith can set active to false', () {
+    final inactive = manager.copyWith(active: false);
+    expect(inactive.active, isFalse);
+    expect(inactive.id, manager.id);
+  });
+
+  test('equality includes active field', () {
+    const userActive = AppUser(
+      id: 'u_x',
+      email: 'x@farm.test',
+      displayName: 'X',
+      role: UserRole.worker,
+    );
+    const userInactive = AppUser(
+      id: 'u_x',
+      email: 'x@farm.test',
+      displayName: 'X',
+      role: UserRole.worker,
+      active: false,
+    );
+    expect(userActive, isNot(equals(userInactive)));
+    expect(userActive.hashCode, isNot(equals(userInactive.hashCode)));
   });
 
   test('Iterable lookup returns matching users and handles null ids', () {

--- a/test/features/auth/firebase_auth_repository_test.dart
+++ b/test/features/auth/firebase_auth_repository_test.dart
@@ -227,5 +227,21 @@ void main() {
       final first = await repo.authStateChanges().first;
       expect(first, isNull);
     });
+
+    test('emits null when user doc has active=false', () async {
+      final user = MockUser(uid: 'u_inactive', email: 'inactive@farm.test');
+      final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('u_inactive').set({
+        'email': 'inactive@farm.test',
+        'displayName': 'Inactive Worker',
+        'role': 'worker',
+        'active': false,
+      });
+
+      final repo = FirebaseAuthRepository(auth: auth, firestore: firestore);
+      final first = await repo.authStateChanges().first;
+      expect(first, isNull);
+    });
   });
 }


### PR DESCRIPTION
Closes #78.

## Summary

- Add `isActive()` helper to `firestore.rules`; all read/write paths now require `active != false` on the calling user's document — inactive workers and managers are locked out immediately without deleting their Auth credential.
- Add `active: bool` field to `AppUser` domain class (defaults to `true`); wired through `fromMap`/`toMap`/`copyWith`/equality/`toString`.
- `FirebaseAuthRepository.authStateChanges` returns `null` when the user doc has `active: false`, so an inactive account is treated as signed-out at the app level too.
- Seed fixtures for `inactive_worker` and `inactive_manager`; new rules-test cases cover all blocked paths: read crops/users/lists, claim, mark picked, release, write crops/templates.
- Deactivation procedure documented in `docs/setup.md`.

## Test plan

- [ ] `flutter test test/features/auth/` — 26 tests pass
- [ ] `cd firebase/rules-tests && npm run emulators:exec` — all inactive-user rules tests pass (requires local emulator; covered by CI job from #77)