### PR TITLE
test: Firestore emulator integration test + CI job (FIRE-04 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,47 @@ jobs:
         working-directory: firebase/rules-tests
         run: npm run emulators:exec
 
+  flutter_emulator_integration:
+    name: Firestore emulator integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          flutter-version: '3.41.x'
+          cache: true
+
+      - name: Install firebase-tools
+        run: npm install -g firebase-tools@^15.0.0
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Run integration tests against Firestore emulator
+        working-directory: firebase
+        run: >
+          firebase emulators:exec
+          --only firestore
+          --project demo-pickllist
+          "flutter test ../integration_test/ -d chrome"
+
   windows_build:
     name: Build Windows app
     runs-on: windows-latest

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -104,6 +104,31 @@ $env:FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099'
 
 The Firebase impls will read these at startup.
 
+## Firestore emulator integration tests
+
+`integration_test/firestore_picking_list_repository_emulator_test.dart`
+exercises `FirestorePickingListRepository` against a real emulator. The
+CI job runs automatically; to run it locally:
+
+```sh
+# One-shot: emulator starts, tests run, emulator stops.
+cd firebase
+firebase emulators:exec \
+  --only firestore \
+  --project demo-pickllist \
+  "flutter test ../integration_test/ -d chrome"
+```
+
+Or, if the emulator is already running (from `emulators:start`):
+
+```sh
+flutter test integration_test/ -d chrome
+```
+
+Chrome must be installed (it is available on all CI runners and most
+developer machines). The test file uses stub `FirebaseOptions` so no
+real Firebase project or API key is required.
+
 ## Local Functions emulator
 
 Cloud Functions live in `firebase/functions/`. Local development uses the

--- a/integration_test/firestore_picking_list_repository_emulator_test.dart
+++ b/integration_test/firestore_picking_list_repository_emulator_test.dart
@@ -1,0 +1,166 @@
+// Emulator-backed integration tests for [FirestorePickingListRepository].
+//
+// Prerequisites: `firebase emulators:start --only firestore --project
+// demo-pickllist` (the CI job handles this via `emulators:exec`).
+//
+// Run locally:
+//   cd firebase && firebase emulators:exec --only firestore \
+//     --project demo-pickllist "flutter test integration_test/ -d chrome"
+//
+// Or from the repo root if the emulator is already running:
+//   flutter test integration_test/ -d chrome
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pickllist/features/picking_lists/data/firestore_picking_list_repository.dart';
+import 'package:pickllist/features/picking_lists/domain/picking_list.dart';
+import 'package:pickllist/features/picking_lists/domain/quantity_unit.dart';
+
+/// Minimal stub options that satisfy Firebase SDK validation.
+/// The SDK never uses these values when the emulator is active.
+const _kOptions = FirebaseOptions(
+  apiKey: 'fake-api-key',
+  appId: '1:000000000000:web:000000000000',
+  messagingSenderId: '000000000000',
+  projectId: 'demo-pickllist',
+  storageBucket: 'demo-pickllist.appspot.com',
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late FirebaseFirestore firestore;
+  late FirestorePickingListRepository repo;
+
+  setUpAll(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp(options: _kOptions);
+    firestore = FirebaseFirestore.instance
+      // Point all Firestore calls at the local emulator.
+      ..useFirestoreEmulator('localhost', 8080);
+    repo = FirestorePickingListRepository(firestore);
+  });
+
+  test('createList persists a draft list readable via watchLists', () async {
+    final listId = await repo.createList(
+      name: 'Emulator smoke list',
+      scheduledAt: DateTime(2026, 5),
+      createdBy: 'manager_emulator',
+    );
+
+    expect(listId, isNotEmpty);
+
+    final lists = await repo.watchLists().first;
+    final created = lists.where((l) => l.id == listId).toList();
+    expect(created, hasLength(1));
+    expect(created.first.name, 'Emulator smoke list');
+    expect(created.first.status, PickingListStatus.draft);
+    expect(created.first.createdBy, 'manager_emulator');
+  });
+
+  test('addItem persists a row and watchItems streams it back', () async {
+    final listId = await repo.createList(
+      name: 'Items smoke list',
+      scheduledAt: DateTime(2026, 5),
+      createdBy: 'manager_emulator',
+    );
+
+    final itemId = await repo.addItem(
+      listId: listId,
+      cropId: 'c_tomato',
+      cropName: 'Tomatoes',
+      quantity: 10,
+      unit: QuantityUnit.kg,
+    );
+
+    expect(itemId, isNotEmpty);
+
+    final items = await repo.watchItems(listId).first;
+    expect(items, hasLength(1));
+    expect(items.first.id, itemId);
+    expect(items.first.cropName, 'Tomatoes');
+    expect(items.first.quantity, 10);
+    expect(items.first.unit, QuantityUnit.kg);
+    expect(items.first.assignedTo, isNull);
+  });
+
+  test('claimItem assigns the row to the requesting worker', () async {
+    final listId = await repo.createList(
+      name: 'Claim smoke list',
+      scheduledAt: DateTime(2026, 5),
+      createdBy: 'manager_emulator',
+    );
+    final itemId = await repo.addItem(
+      listId: listId,
+      cropId: 'c_pepper',
+      cropName: 'Peppers',
+      quantity: 5,
+      unit: QuantityUnit.units,
+    );
+
+    await repo.claimItem(
+      listId: listId,
+      itemId: itemId,
+      userId: 'worker_emulator',
+    );
+
+    final items = await repo.watchItems(listId).first;
+    final claimed = items.firstWhere((i) => i.id == itemId);
+    expect(claimed.assignedTo, 'worker_emulator');
+  });
+
+  test('concurrent claimItem race: exactly one worker wins', () async {
+    // Create a fresh unassigned row so neither worker has an advantage.
+    final listId = await repo.createList(
+      name: 'Race list',
+      scheduledAt: DateTime(2026, 5),
+      createdBy: 'manager_emulator',
+    );
+    final itemId = await repo.addItem(
+      listId: listId,
+      cropId: 'c_lettuce',
+      cropName: 'Lettuce',
+      quantity: 20,
+      unit: QuantityUnit.kg,
+    );
+
+    // Two repository instances backed by the same Firestore instance race to
+    // claim the same row.  One transaction must win; the other must be
+    // rejected with already-assigned (possibly after the SDK retries).
+    final repoA = FirestorePickingListRepository(firestore);
+    final repoB = FirestorePickingListRepository(firestore);
+
+    String? winner;
+    var failures = 0;
+
+    await Future.wait([
+      repoA
+          .claimItem(listId: listId, itemId: itemId, userId: 'worker_a')
+          .then((_) {
+            winner = 'worker_a';
+          })
+          .catchError((_) {
+            failures++;
+          }),
+      repoB
+          .claimItem(listId: listId, itemId: itemId, userId: 'worker_b')
+          .then((_) {
+            winner ??= 'worker_b';
+          })
+          .catchError((_) {
+            failures++;
+          }),
+    ]);
+
+    // Exactly one claim succeeded and one failed.
+    expect(failures, 1, reason: 'exactly one claimItem should be rejected');
+    expect(winner, isNotNull, reason: 'exactly one worker should win');
+
+    // The winning UID is on the item in Firestore.
+    final items = await repo.watchItems(listId).first;
+    final raced = items.firstWhere((i) => i.id == itemId);
+    expect(raced.assignedTo, winner);
+  });
+}


### PR DESCRIPTION
Closes #76.

## Summary

- New `integration_test/firestore_picking_list_repository_emulator_test.dart` with four emulator-backed cases:
  - `createList` persists a draft list visible via `watchLists`
  - `addItem` + `watchItems` round-trip
  - `claimItem` assigns the row to the requesting worker
  - Concurrent `claimItem` race: `Future.wait` fires two competing transactions; verifies exactly one wins and the Firestore doc reflects the winner's UID
- New `flutter_emulator_integration` CI job (`ubuntu-latest`): installs Java + Firebase CLI, then runs `firebase emulators:exec --only firestore --project demo-pickllist "flutter test integration_test/ -d chrome"`
- `docs/setup.md`: documents local emulator integration test workflow (both one-shot via `emulators:exec` and incremental with a running emulator)

## Test plan

- [ ] `flutter analyze integration_test/` — no issues
- [ ] CI `flutter_emulator_integration` job passes (requires live Firestore emulator; validated on push)